### PR TITLE
Add detailed UI/UX planning deliverables

### DIFF
--- a/ui-ux-planning.md
+++ b/ui-ux-planning.md
@@ -1,0 +1,81 @@
+# UI ir UX planavimo dokumentas
+
+Šis dokumentas detaliai išskaido planavimo darbus, reikalingus išlaidų sekimo aplikacijos UI ir UX įgyvendinimui pagal `design-guidelines.md` nurodymus ir ankstesnį 7 žingsnių planą.
+
+## 1. Dizaino gairių atitikties auditas
+- **Tikslas:** prieš pradedant kūrimą suderinti visą komandą dėl kalbos tono, valiutų rašybos, išdėstymo ritmo ir komponentų būsenų naudojimo.
+- **Veiksmai:**
+  - Surinkti kontrolinį sąrašą iš `design-guidelines.md`, `STYLEGUIDE.md` ir `ACCESSIBILITY.md`.
+  - Patvirtinti kalbos toną (ramus, praktinis), EUR valiutos formatą, datos formatą, UI komponentų būsenas.
+  - Įtraukti UX rašytoją ir QA į peržiūrą.
+- **Išvestis:** 1 puslapio `checklist-ui-ux.md` dokumentas su parašais.
+- **Terminas:** 0,5 dienos.
+
+## 2. UI dizaino sistemos sukūrimas
+- **Tikslas:** apibrėžti dizaino tokenus ir komponentų biblioteką React aplinkai.
+- **Veiksmai:**
+  - Sukurti `tokens.json` (spalvos, tipografija, spacing 8 px ritmu) `src/design-system/` kataloge.
+  - Apibrėžti pagrindinius komponentus (`Button`, `Badge`, `Card`, `Tabs`) su Storybook story stubais.
+  - Parengti `theme.css` su CSS kintamaisiais.
+- **Išvestis:** `src/design-system/README.md`, `tokens.json`, komponentų stubai.
+- **Terminas:** 1 diena.
+
+## 3. UX rašymo gairių parengimas
+- **Tikslas:** užtikrinti nuoseklią mikrocopy visiems UI elementams.
+- **Veiksmai:**
+  - Parengti teksto šablonus tuščioms būsenoms, toast'ams, formų laukams.
+  - Suderinti terminus (pvz., „Išlaidos“, „Biudžetas“, „Ataskaita“).
+  - Įtraukti skiltį apie balso toną ir `Do/Don't` pavyzdžius.
+- **Išvestis:** `content-guidelines.md` dokumentas.
+- **Terminas:** 0,5 dienos.
+
+## 4. Puslapių dizaino iteracijos
+- **Tikslas:** suplanuoti kiekvieno pagrindinio puslapio įgyvendinimą pagal vartotojų srautus.
+- **Veiksmai:**
+  - **Log puslapis:** specifikuoti įvedimo formą, filtrus, undo, navigacijos CTA.
+  - **Budgets puslapis:** apibrėžti limitų tinklelį, carry-over logiką, statuso ženkliukus.
+  - **Reports puslapis:** suplanuoti 3 diagramų maketus, tabų struktūrą, insight tekstus.
+  - **Settings puslapis:** nustatyti duomenų valdymo, kategorijų CRUD ir pagalbos sekcijas.
+  - Kiekvienam puslapiui parengti `wireflow` ir `interaction checklist`.
+- **Išvestis:** `ui-flows/` katalogas su `.drawio` arba `.fig` failais ir `README` su santraukomis.
+- **Terminas:** 1,5 dienos.
+
+## 5. UI būsenų sinchronizacija su duomenų logika
+- **Tikslas:** dokumentuoti, kaip domeno logika maitina UI komponentus.
+- **Veiksmai:**
+  - Sudaryti žemėlapį tarp `src/services` atsakymų ir UI būsenų (OK/Approaching/Over).
+  - Aprašyti spalvų ir ikonų naudojimą kiekvienai būsenai.
+  - Nustatyti klaidų ir pakartojimų tvarkymą (retry, offline).
+- **Išvestis:** `state-mapping.md` su diagramomis ir pseudo-kodu.
+- **Terminas:** 0,5 dienos.
+
+## 6. Prieinamumo ir sąveikos planas
+- **Tikslas:** užtikrinti WCAG 2.1 AA reikalavimus.
+- **Veiksmai:**
+  - Sudaryti klaviatūros navigacijos scenarijų sąrašą kiekvienam puslapiui.
+  - Aprašyti fokusų matomumo standartą ir `aria` etikečių schemą.
+  - Numatyti grafinių komponentų (Chart.js) alternatyvias tekstines santraukas.
+- **Išvestis:** `a11y-plan.md` dokumentas ir `focus-styles.css` stubas.
+- **Terminas:** 0,5 dienos.
+
+## 7. QA ir pristatymo patvirtinimas
+- **Tikslas:** nustatyti validacijos procesą, užtikrinantį, kad UI/UX sprendimai atitinka gaires.
+- **Veiksmai:**
+  - Parengti testų kontrolinį sąrašą (lint, vizualinė peržiūra, kopijos QA, diagramų stiliai).
+  - Nustatyti, kada vykdomos iteracijos su dizaineriu ir produktų savininku.
+  - Suplanuoti galutinę QA sesiją ir ataskaitos formatą.
+- **Išvestis:** `qa-readiness-checklist.md`.
+- **Terminas:** 0,5 dienos.
+
+## Grafikas ir atsakomybės
+| Žingsnis | Trukmė | Pagrindinis atsakingas | Dalyviai |
+| --- | --- | --- | --- |
+| 1 | 0,5 d. | UX lead | QA, PM |
+| 2 | 1 d. | UI lead | Frontend inžinierius |
+| 3 | 0,5 d. | UX rašytojas | UX lead |
+| 4 | 1,5 d. | UX/UI tandemas | PM, duomenų analitikas |
+| 5 | 0,5 d. | Frontend inžinierius | UX lead |
+| 6 | 0,5 d. | A11y specialistas | UI lead |
+| 7 | 0,5 d. | QA lead | Visi |
+
+**Bendra planavimo trukmė:** ~5 dienos (sudėjus žingsnius, leidžiant dalinį persidengimą tarp 3, 5 ir 6 žingsnių).


### PR DESCRIPTION
## Summary
- document the detailed UI and UX planning tasks derived from the previously agreed 7-step plan
- outline responsibilities, outputs, and timelines for each planning track to align the team around the design guidelines

## Testing
- not run (documentation change)

------
https://chatgpt.com/codex/tasks/task_e_68d953f1889c8326acd8f66a0f2c66f5