### PR TITLE
Expand testing coverage and configure CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Unit tests
+        run: npm run test:unit
+
+      - name: Build
+        run: npm run build
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: End-to-end tests
+        run: npm run test:e2e
+        env:
+          PLAYWRIGHT_BASE_URL: http://127.0.0.1:4173
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+coverage/
+playwright-report/
+test-results/
+.vitest/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Expense Tracker (Desktop, EUR, English)
 
+[![CI](https://github.com/your-org/simple-ledger/actions/workflows/ci.yml/badge.svg)](https://github.com/your-org/simple-ledger/actions/workflows/ci.yml)
+
 Manual expense logging with monthly category budgets and clear charts. Local-first (IndexedDB), no accounts.
 
 ## Features (MVP)
@@ -9,18 +11,20 @@ Manual expense logging with monthly category budgets and clear charts. Local-fir
 - Export/Import JSON backups
 
 ## Quick start
-1. Install dependencies: `pnpm install`
-2. Start development server: `pnpm dev`
+1. Install dependencies: `npm install`
+2. Start development server: `npm run dev`
 3. Visit http://localhost:5173
 
-> **Note:** Package downloads require internet access. In restricted environments run `pnpm install --offline` with a prepared store.
+> **Note:** Package downloads require internet access. In restricted environments use a local npm mirror or pre-populated cache (`npm install --prefer-offline`).
 
 ## Available scripts
-- `pnpm dev` — start Vite development server
-- `pnpm build` — type-check and create production build
-- `pnpm preview` — serve the production build locally
-- `pnpm lint` — run ESLint against TypeScript/React sources
-- `pnpm test` — execute unit tests with Vitest (to be added in later stages)
+- `npm run dev` — start the Vite development server
+- `npm run build` — type-check and create the production build
+- `npm run preview` — serve the production build locally
+- `npm run lint` — run ESLint against TypeScript/React sources
+- `npm run test` — execute unit tests in watch mode with Vitest
+- `npm run test:unit` — run the Vitest suite once with coverage enabled
+- `npm run test:e2e` — launch the Playwright test runner (requires a production build)
 
 ## Tech stack
 - React 18 + TypeScript
@@ -37,10 +41,10 @@ src/
   styles/         # Global design tokens and base theme
 ```
 
-Upcoming directories:
-- `src/db` for Dexie schema
+Additional directories of note:
+- `src/db` for the Dexie schema and database helpers
 - `src/services` for domain services
-- `src/utils` for formatting helpers
+- `src/utils` for shared utility functions and React hooks
 
 ## Contributing
 See `CONTRIBUTING.md`. Code of Conduct: `CODE_OF_CONDUCT.md`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Expense Tracker (Desktop, EUR, English)
 
-[![CI](https://github.com/your-org/simple-ledger/actions/workflows/ci.yml/badge.svg)](https://github.com/your-org/simple-ledger/actions/workflows/ci.yml)
+[![CI][ci-badge]][ci-workflow]
 
 Manual expense logging with monthly category budgets and clear charts. Local-first (IndexedDB), no accounts.
 
@@ -11,20 +11,27 @@ Manual expense logging with monthly category budgets and clear charts. Local-fir
 - Export/Import JSON backups
 
 ## Quick start
+
+### Using pnpm (recommended)
+1. Install dependencies: `pnpm install`
+2. Start development server: `pnpm dev`
+3. Visit http://localhost:5173
+
+### Using npm
 1. Install dependencies: `npm install`
 2. Start development server: `npm run dev`
 3. Visit http://localhost:5173
 
-> **Note:** Package downloads require internet access. In restricted environments use a local npm mirror or pre-populated cache (`npm install --prefer-offline`).
+> **Note:** Package downloads require internet access. In restricted environments use a local npm mirror or a pre-populated cache (`pnpm install --offline` or `npm install --prefer-offline`).
 
 ## Available scripts
-- `npm run dev` — start the Vite development server
-- `npm run build` — type-check and create the production build
-- `npm run preview` — serve the production build locally
-- `npm run lint` — run ESLint against TypeScript/React sources
-- `npm run test` — execute unit tests in watch mode with Vitest
-- `npm run test:unit` — run the Vitest suite once with coverage enabled
-- `npm run test:e2e` — launch the Playwright test runner (requires a production build)
+- `pnpm dev` / `npm run dev` — start the Vite development server
+- `pnpm build` / `npm run build` — type-check and create the production build
+- `pnpm preview` / `npm run preview` — serve the production build locally
+- `pnpm lint` / `npm run lint` — run ESLint against TypeScript/React sources
+- `pnpm test` / `npm run test` — execute unit tests in watch mode with Vitest
+- `pnpm test:unit` / `npm run test:unit` — run the Vitest suite once with coverage enabled
+- `pnpm test:e2e` / `npm run test:e2e` — launch the Playwright test runner (requires a production build)
 
 ## Tech stack
 - React 18 + TypeScript
@@ -51,3 +58,6 @@ See `CONTRIBUTING.md`. Code of Conduct: `CODE_OF_CONDUCT.md`.
 
 ## License
 See `LICENSE`.
+
+[ci-badge]: https://github.com/your-org/simple-ledger/actions/workflows/ci.yml/badge.svg
+[ci-workflow]: https://github.com/your-org/simple-ledger/actions/workflows/ci.yml

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,32 @@
 # Releasing
 
-1. Update version in `package.json`
-2. Update `CHANGELOG.md`
-3. Build: `npm run build`
-4. Deploy static `dist/` to Netlify/Vercel/GitHub Pages
+Use this checklist to publish a stable build.
+
+## Pre-release
+
+- [ ] Confirm the target branch is up to date with `main`.
+- [ ] Review open issues/PRs for blockers and update status labels.
+- [ ] Update the version in `package.json` and create a corresponding entry in `CHANGELOG.md`.
+- [ ] Run quality gates locally:
+  - [ ] `npm run lint`
+  - [ ] `npm run test:unit`
+  - [ ] `npm run build`
+  - [ ] `npx playwright install` (first run only) and `npm run test:e2e`
+- [ ] Execute a manual JSON backup/import round-trip using [`tests/fixtures/sample-backup.json`](tests/fixtures/sample-backup.json):
+  1. Import the fixture via the Settings page.
+  2. Export a new backup and verify the structure matches expectations.
+  3. Clear data and re-import the exported file to confirm state is restored.
+- [ ] Validate browser compatibility by exercising the smoke tests in Chromium, Firefox, and WebKit (Playwright projects cover this, but perform a quick manual spot-check if UI changes were made).
+
+## Release
+
+- [ ] Create a release branch (`release/vX.Y.Z`) and push it for review.
+- [ ] Ensure CI (`CI` workflow badge) is green on the release branch.
+- [ ] Tag the release (`git tag vX.Y.Z && git push origin vX.Y.Z`).
+- [ ] Publish release notes summarising key changes and linking to the changelog entry.
+
+## Post-release
+
+- [ ] Merge the release branch back into `main` (and `develop` if applicable).
+- [ ] Update documentation or project boards with any follow-up actions.
+- [ ] Celebrate responsibly 🎉

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
-    "test": "vitest"
+    "test": "vitest --watch",
+    "test:unit": "vitest run --coverage",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@paralleldrive/cuid2": "^2.2.2",
@@ -21,6 +23,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@playwright/test": "^1.44.0",
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^14.2.1",
     "@testing-library/user-event": "^14.5.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const PORT = process.env.PLAYWRIGHT_PORT ?? '4173';
+const HOST = process.env.PLAYWRIGHT_HOST ?? '127.0.0.1';
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? `http://${HOST}:${PORT}`;
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : [['list'], ['html', { open: 'never' }]],
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+    headless: true
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] }
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] }
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] }
+    }
+  ],
+  webServer: {
+    command: process.env.CI
+      ? `npm run preview -- --host 0.0.0.0 --port ${PORT}`
+      : `npm run dev -- --host 0.0.0.0 --port ${PORT}`,
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    stdout: 'pipe',
+    stderr: 'pipe'
+  }
+});

--- a/src/services/__tests__/backup.service.test.ts
+++ b/src/services/__tests__/backup.service.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { clearAllData, exportBackup, importBackup } from '../backup';
+import type { BudgetRecord, CategoryRecord, ExpenseRecord, SettingRecord } from '@db/db';
+import { createMockDatabase } from '@test/utils/mockDatabase';
+import { getCurrentIsoTimestamp } from '@utils/dates';
+
+vi.mock('@utils/dates', async () => {
+  const actual = await vi.importActual<typeof import('@utils/dates')>('@utils/dates');
+  return {
+    ...actual,
+    getCurrentIsoTimestamp: vi.fn(() => '2024-05-01T00:00:00.000Z')
+  };
+});
+
+const category: CategoryRecord = {
+  id: 'cat-1',
+  name: 'Food',
+  color: '#ff0000',
+  isHidden: false,
+  createdAt: '2024-05-01T00:00:00.000Z',
+  updatedAt: '2024-05-01T00:00:00.000Z'
+};
+
+const budget: BudgetRecord = {
+  id: 'budget-1',
+  month: '2024-05',
+  categoryId: 'cat-1',
+  limitCents: 30_000,
+  carryOverPrev: false,
+  createdAt: '2024-05-01T00:00:00.000Z',
+  updatedAt: '2024-05-01T00:00:00.000Z'
+};
+
+const expense: ExpenseRecord = {
+  id: 'exp-1',
+  amountCents: 12_000,
+  currency: 'EUR',
+  date: '2024-05-02T00:00:00.000Z',
+  month: '2024-05',
+  categoryId: 'cat-1',
+  createdAt: '2024-05-02T00:00:00.000Z',
+  updatedAt: '2024-05-02T00:00:00.000Z'
+};
+
+const settings: SettingRecord[] = [
+  { key: 'currency', value: 'EUR' },
+  { key: 'theme', value: 'dark' }
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getCurrentIsoTimestamp).mockReturnValue('2024-05-01T00:00:00.000Z');
+});
+
+describe('exportBackup', () => {
+  it('returns validated payload with timestamp', async () => {
+    const database = createMockDatabase({
+      categories: [category],
+      budgets: [budget],
+      expenses: [expense],
+      settings
+    });
+    vi.mocked(getCurrentIsoTimestamp).mockReturnValue('2024-05-30T12:00:00.000Z');
+
+    const payload = await exportBackup(database);
+
+    expect(payload).toMatchObject({
+      version: 1,
+      exportedAt: '2024-05-30T12:00:00.000Z',
+      categories: [expect.objectContaining({ id: 'cat-1' })],
+      budgets: [expect.objectContaining({ id: 'budget-1' })],
+      expenses: [expect.objectContaining({ id: 'exp-1' })],
+      settings: expect.arrayContaining([expect.objectContaining({ key: 'currency' })])
+    });
+  });
+});
+
+describe('clearAllData', () => {
+  it('clears tables except settings when requested', async () => {
+    const database = createMockDatabase({
+      categories: [category],
+      budgets: [budget],
+      expenses: [expense],
+      settings
+    });
+
+    await clearAllData(database, { keepSettings: true });
+
+    expect(await database.categories.toArray()).toHaveLength(0);
+    expect(await database.settings.toArray()).toHaveLength(settings.length);
+  });
+});
+
+describe('importBackup', () => {
+  const payload = {
+    version: 1,
+    exportedAt: '2024-05-15T00:00:00.000Z',
+    categories: [category],
+    budgets: [budget],
+    expenses: [expense],
+    settings
+  };
+
+  it('replaces existing data when merge is false', async () => {
+    const database = createMockDatabase({
+      categories: [
+        { ...category, id: 'legacy', name: 'Legacy', createdAt: '2024-04-01T00:00:00.000Z', updatedAt: '2024-04-01T00:00:00.000Z' }
+      ],
+      budgets: [],
+      expenses: [],
+      settings: [{ key: 'theme', value: 'light' }]
+    });
+
+    await importBackup(payload, { keepExistingSettings: true }, database);
+
+    expect(await database.categories.toArray()).toHaveLength(1);
+    expect(await database.settings.toArray()).toEqual(settings);
+  });
+
+  it('merges by removing duplicates before inserting', async () => {
+    const database = createMockDatabase({ categories: [category], budgets: [budget], expenses: [expense], settings });
+
+    await importBackup(payload, { merge: true }, database);
+
+    expect(await database.categories.toArray()).toHaveLength(1);
+    expect(await database.expenses.toArray()).toHaveLength(1);
+    expect(await database.settings.toArray()).toEqual(settings);
+  });
+});

--- a/src/services/__tests__/budget.service.test.ts
+++ b/src/services/__tests__/budget.service.test.ts
@@ -1,65 +1,226 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { buildBudgetSnapshots } from '../budget';
-import type { Budget, Expense } from '@domain/types';
+import {
+  buildBudgetSnapshots,
+  createBudget,
+  deleteBudget,
+  getBudgetById,
+  getBudgetSnapshots,
+  listBudgets,
+  updateBudget
+} from '../budget';
+import type { BudgetRecord, ExpenseRecord } from '@db/db';
+import * as budgetDomain from '@domain/budget';
+import { createMockDatabase } from '@test/utils/mockDatabase';
+import { getCurrentIsoTimestamp } from '@utils/dates';
 
-const aprilBudget: Budget = {
-  id: 'budget-apr',
-  month: '2024-04',
-  categoryId: 'cat-1',
+vi.mock('@utils/dates', async () => {
+  const actual = await vi.importActual<typeof import('@utils/dates')>('@utils/dates');
+  return {
+    ...actual,
+    getCurrentIsoTimestamp: vi.fn(() => '2024-05-01T00:00:00.000Z')
+  };
+});
+
+const baseBudget: BudgetRecord = {
+  id: 'budget-1',
+  month: '2024-05',
+  categoryId: 'groceries',
   limitCents: 40000,
   carryOverPrev: false,
-  createdAt: '2024-04-01T00:00:00.000Z',
-  updatedAt: '2024-04-01T00:00:00.000Z'
-};
-
-const mayBudget: Budget = {
-  id: 'budget-may',
-  month: '2024-05',
-  categoryId: 'cat-1',
-  limitCents: 30000,
-  carryOverPrev: true,
   createdAt: '2024-05-01T00:00:00.000Z',
   updatedAt: '2024-05-01T00:00:00.000Z'
 };
 
-const aprilExpense: Expense = {
-  id: 'exp-apr',
-  amountCents: 25000,
-  currency: 'EUR',
-  date: '2024-04-10T00:00:00.000Z',
+const previousBudget: BudgetRecord = {
+  ...baseBudget,
+  id: 'budget-previous',
   month: '2024-04',
-  categoryId: 'cat-1',
-  note: 'Groceries',
-  createdAt: '2024-04-10T00:00:00.000Z',
-  updatedAt: '2024-04-10T00:00:00.000Z'
+  limitCents: 30000,
+  carryOverPrev: true,
+  createdAt: '2024-04-01T00:00:00.000Z',
+  updatedAt: '2024-04-01T00:00:00.000Z'
 };
 
-const mayExpense: Expense = {
-  id: 'exp-may',
-  amountCents: 35000,
-  currency: 'EUR',
-  date: '2024-05-12T00:00:00.000Z',
-  month: '2024-05',
-  categoryId: 'cat-1',
-  note: 'Rent',
-  createdAt: '2024-05-12T00:00:00.000Z',
-  updatedAt: '2024-05-12T00:00:00.000Z'
-};
+const expenses: ExpenseRecord[] = [
+  {
+    id: 'exp-1',
+    amountCents: 12_500,
+    currency: 'EUR',
+    date: '2024-05-10T00:00:00.000Z',
+    month: '2024-05',
+    categoryId: 'groceries',
+    note: 'snacks',
+    createdAt: '2024-05-10T00:00:00.000Z',
+    updatedAt: '2024-05-10T00:00:00.000Z'
+  }
+];
 
-describe('buildBudgetSnapshots', () => {
-  it('computes carry-over and status', () => {
-    const [snapshot] = buildBudgetSnapshots({
-      month: '2024-05',
-      budgets: [mayBudget],
-      expenses: [mayExpense],
-      previousBudgets: [aprilBudget],
-      previousExpenses: [aprilExpense]
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getCurrentIsoTimestamp).mockReturnValue('2024-05-01T00:00:00.000Z');
+});
+
+describe('listBudgets', () => {
+  it('filters by month and category when provided', async () => {
+    const database = createMockDatabase({
+      budgets: [
+        baseBudget,
+        { ...baseBudget, id: 'budget-2', month: '2024-04' },
+        { ...baseBudget, id: 'budget-3', categoryId: 'rent' }
+      ]
     });
 
-    expect(snapshot.carryInCents).toBe(15000);
-    expect(snapshot.actualCents).toBe(35000);
-    expect(snapshot.availableCents).toBe(10000);
-    expect(snapshot.status).toBe('approaching');
+    const result = await listBudgets({ month: '2024-05', categoryId: 'groceries' }, database);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ id: 'budget-1', month: '2024-05', categoryId: 'groceries' });
+  });
+});
+
+describe('getBudgetById', () => {
+  it('returns parsed budget or null when missing', async () => {
+    const database = createMockDatabase({ budgets: [baseBudget] });
+
+    await expect(getBudgetById('budget-1', database)).resolves.toMatchObject({ id: 'budget-1' });
+    await expect(getBudgetById('missing', database)).resolves.toBeNull();
+  });
+});
+
+describe('createBudget', () => {
+  it('validates payload, fills defaults and persists record', async () => {
+    const database = createMockDatabase();
+    vi.mocked(getCurrentIsoTimestamp).mockReturnValue('2024-06-01T00:00:00.000Z');
+
+    const created = await createBudget(
+      {
+        month: '2024-06',
+        categoryId: 'travel',
+        limitCents: 50_000
+      },
+      database
+    );
+
+    expect(created).toMatchObject({
+      id: 'generated-id',
+      month: '2024-06',
+      categoryId: 'travel',
+      carryOverPrev: false,
+      limitCents: 50_000,
+      createdAt: '2024-06-01T00:00:00.000Z',
+      updatedAt: '2024-06-01T00:00:00.000Z'
+    });
+  });
+
+  it('prevents creating duplicate budgets for the same category and month', async () => {
+    const database = createMockDatabase({ budgets: [baseBudget] });
+
+    await expect(
+      createBudget(
+        {
+          month: '2024-05',
+          categoryId: 'groceries',
+          limitCents: 30_000
+        },
+        database
+      )
+    ).rejects.toThrowError('Budget for this category and month already exists');
+  });
+});
+
+describe('updateBudget', () => {
+  it('updates persisted record with patch values', async () => {
+    const database = createMockDatabase({ budgets: [baseBudget] });
+    vi.mocked(getCurrentIsoTimestamp).mockReturnValue('2024-05-05T12:00:00.000Z');
+
+    const updated = await updateBudget(
+      'budget-1',
+      {
+        limitCents: 42_000,
+        carryOverPrev: true
+      },
+      database
+    );
+
+    expect(updated).toMatchObject({
+      limitCents: 42_000,
+      carryOverPrev: true,
+      updatedAt: '2024-05-05T12:00:00.000Z'
+    });
+  });
+
+  it('throws when the budget does not exist', async () => {
+    const database = createMockDatabase();
+    await expect(updateBudget('missing', { limitCents: 10_000 }, database)).rejects.toThrowError(
+      'Budget missing not found'
+    );
+  });
+});
+
+describe('deleteBudget', () => {
+  it('removes the record', async () => {
+    const database = createMockDatabase({ budgets: [baseBudget] });
+
+    await deleteBudget('budget-1', database);
+
+    await expect(listBudgets({}, database)).resolves.toHaveLength(0);
+  });
+});
+
+describe('getBudgetSnapshots', () => {
+  it('combines current and previous data to build snapshots', async () => {
+    const database = createMockDatabase({
+      budgets: [baseBudget, previousBudget],
+      expenses: [
+        ...expenses,
+        {
+          id: 'exp-prev',
+          amountCents: 10_000,
+          currency: 'EUR',
+          date: '2024-04-10T00:00:00.000Z',
+          month: '2024-04',
+          categoryId: 'groceries',
+          createdAt: '2024-04-10T00:00:00.000Z',
+          updatedAt: '2024-04-10T00:00:00.000Z'
+        }
+      ]
+    });
+
+    const snapshots = await getBudgetSnapshots('2024-05', database);
+
+    expect(snapshots).toHaveLength(1);
+    expect(snapshots[0]).toMatchObject({
+      month: '2024-05',
+      actualCents: 12_500,
+      carryInCents: 20_000
+    });
+  });
+});
+
+describe('buildBudgetSnapshots', () => {
+  it('propagates previous budget information to the calculator', () => {
+    const calculateSpy = vi.spyOn(budgetDomain, 'calculateBudgetSnapshot');
+
+    const snapshots = buildBudgetSnapshots({
+      month: '2024-05',
+      budgets: [baseBudget],
+      expenses,
+      previousBudgets: [previousBudget],
+      previousExpenses: [
+        {
+          ...expenses[0],
+          id: 'exp-prev',
+          month: '2024-04',
+          date: '2024-04-12T00:00:00.000Z'
+        }
+      ]
+    });
+
+    expect(snapshots).toHaveLength(1);
+    expect(calculateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ previousBudget: expect.objectContaining({ id: 'budget-previous' }) })
+    );
+
+    calculateSpy.mockRestore();
   });
 });

--- a/src/services/__tests__/category.service.test.ts
+++ b/src/services/__tests__/category.service.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createCategory,
+  deleteCategory,
+  getCategoryById,
+  listCategories,
+  setCategoryHidden,
+  updateCategory
+} from '../category';
+import type { CategoryRecord, ExpenseRecord } from '@db/db';
+import { createMockDatabase } from '@test/utils/mockDatabase';
+import { getCurrentIsoTimestamp } from '@utils/dates';
+
+vi.mock('@utils/dates', async () => {
+  const actual = await vi.importActual<typeof import('@utils/dates')>('@utils/dates');
+  return {
+    ...actual,
+    getCurrentIsoTimestamp: vi.fn(() => '2024-05-01T00:00:00.000Z')
+  };
+});
+
+const foodCategory: CategoryRecord = {
+  id: 'cat-food',
+  name: 'Food',
+  color: '#ff6600',
+  isHidden: false,
+  createdAt: '2024-04-01T00:00:00.000Z',
+  updatedAt: '2024-04-01T00:00:00.000Z'
+};
+
+const travelCategory: CategoryRecord = {
+  id: 'cat-travel',
+  name: 'Travel',
+  color: '#0033ff',
+  isHidden: true,
+  createdAt: '2024-04-05T00:00:00.000Z',
+  updatedAt: '2024-04-05T00:00:00.000Z'
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getCurrentIsoTimestamp).mockReturnValue('2024-05-01T00:00:00.000Z');
+});
+
+describe('listCategories', () => {
+  it('sorts alphabetically and hides hidden categories by default', async () => {
+    const database = createMockDatabase({ categories: [travelCategory, foodCategory] });
+
+    const result = await listCategories({}, database);
+
+    expect(result).toEqual([
+      expect.objectContaining({ id: 'cat-food' })
+    ]);
+  });
+
+  it('includes hidden categories when requested', async () => {
+    const database = createMockDatabase({ categories: [travelCategory, foodCategory] });
+
+    const result = await listCategories({ includeHidden: true }, database);
+
+    expect(result.map((category) => category.id)).toEqual(['cat-food', 'cat-travel']);
+  });
+});
+
+describe('getCategoryById', () => {
+  it('returns parsed category or null', async () => {
+    const database = createMockDatabase({ categories: [foodCategory] });
+
+    await expect(getCategoryById('cat-food', database)).resolves.toMatchObject({ id: 'cat-food' });
+    await expect(getCategoryById('missing', database)).resolves.toBeNull();
+  });
+});
+
+describe('createCategory', () => {
+  it('trims name, applies defaults and persists record', async () => {
+    const database = createMockDatabase();
+    vi.mocked(getCurrentIsoTimestamp).mockReturnValue('2024-05-10T00:00:00.000Z');
+
+    const created = await createCategory(
+      {
+        name: '  Utilities  ',
+        color: '#00ff00'
+      },
+      database
+    );
+
+    expect(created).toMatchObject({
+      id: 'generated-id',
+      name: 'Utilities',
+      isHidden: false,
+      createdAt: '2024-05-10T00:00:00.000Z',
+      updatedAt: '2024-05-10T00:00:00.000Z'
+    });
+  });
+});
+
+describe('updateCategory', () => {
+  it('updates existing category and normalises nullable color', async () => {
+    const database = createMockDatabase({ categories: [foodCategory] });
+    vi.mocked(getCurrentIsoTimestamp).mockReturnValue('2024-05-20T00:00:00.000Z');
+
+    const updated = await updateCategory(
+      'cat-food',
+      {
+        name: 'Groceries',
+        color: null
+      },
+      database
+    );
+
+    expect(updated).toMatchObject({
+      name: 'Groceries',
+      color: undefined,
+      updatedAt: '2024-05-20T00:00:00.000Z'
+    });
+  });
+
+  it('throws when category does not exist', async () => {
+    const database = createMockDatabase();
+    await expect(updateCategory('missing', { name: 'Anything' }, database)).rejects.toThrowError(
+      'Category missing not found'
+    );
+  });
+});
+
+describe('setCategoryHidden', () => {
+  it('delegates to updateCategory', async () => {
+    const database = createMockDatabase({ categories: [foodCategory] });
+
+    const updated = await setCategoryHidden('cat-food', true, database);
+
+    expect(updated.isHidden).toBe(true);
+  });
+});
+
+describe('deleteCategory', () => {
+  it('prevents deletion when expenses exist for category', async () => {
+    const expense: ExpenseRecord = {
+      id: 'exp-1',
+      amountCents: 1_000,
+      currency: 'EUR',
+      date: '2024-05-01T00:00:00.000Z',
+      month: '2024-05',
+      categoryId: 'cat-food',
+      createdAt: '2024-05-01T00:00:00.000Z',
+      updatedAt: '2024-05-01T00:00:00.000Z'
+    };
+    const database = createMockDatabase({ categories: [foodCategory], expenses: [expense] });
+
+    await expect(deleteCategory('cat-food', database)).rejects.toThrowError(
+      'Cannot delete category that has associated expenses. Consider hiding it instead.'
+    );
+  });
+
+  it('deletes category when not used', async () => {
+    const database = createMockDatabase({ categories: [foodCategory] });
+
+    await deleteCategory('cat-food', database);
+
+    await expect(listCategories({ includeHidden: true }, database)).resolves.toHaveLength(0);
+  });
+});

--- a/src/services/__tests__/expense.service.test.ts
+++ b/src/services/__tests__/expense.service.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createExpense,
+  deleteExpense,
+  getExpenseById,
+  listExpenses,
+  updateExpense
+} from '../expense';
+import type { ExpenseRecord } from '@db/db';
+import { createMockDatabase } from '@test/utils/mockDatabase';
+import { getCurrentIsoTimestamp, getMonthKey } from '@utils/dates';
+
+vi.mock('@utils/dates', async () => {
+  const actual = await vi.importActual<typeof import('@utils/dates')>('@utils/dates');
+  return {
+    ...actual,
+    getCurrentIsoTimestamp: vi.fn(() => '2024-05-01T00:00:00.000Z')
+  };
+});
+
+const groceryExpense: ExpenseRecord = {
+  id: 'exp-1',
+  amountCents: 3_500,
+  currency: 'EUR',
+  date: '2024-05-10T00:00:00.000Z',
+  month: '2024-05',
+  categoryId: 'groceries',
+  note: 'fresh food',
+  createdAt: '2024-05-10T00:00:00.000Z',
+  updatedAt: '2024-05-10T00:00:00.000Z'
+};
+
+const travelExpense: ExpenseRecord = {
+  id: 'exp-2',
+  amountCents: 20_000,
+  currency: 'EUR',
+  date: '2024-04-03T00:00:00.000Z',
+  month: '2024-04',
+  categoryId: 'travel',
+  note: 'flights',
+  createdAt: '2024-04-03T00:00:00.000Z',
+  updatedAt: '2024-04-03T00:00:00.000Z'
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getCurrentIsoTimestamp).mockReturnValue('2024-05-01T00:00:00.000Z');
+});
+
+describe('listExpenses', () => {
+  it('filters by month, category, search and applies ordering with optional limit', async () => {
+    const database = createMockDatabase({ expenses: [groceryExpense, travelExpense] });
+
+    const result = await listExpenses(
+      {
+        month: '2024-05',
+        categoryId: 'groceries',
+        search: 'FOOD',
+        order: 'asc'
+      },
+      database
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ id: 'exp-1' });
+
+    const limited = await listExpenses({ limit: 1 }, database);
+    expect(limited).toHaveLength(1);
+    expect(limited[0].id).toBe('exp-1');
+  });
+});
+
+describe('getExpenseById', () => {
+  it('returns parsed expense or null', async () => {
+    const database = createMockDatabase({ expenses: [groceryExpense] });
+
+    await expect(getExpenseById('exp-1', database)).resolves.toMatchObject({ id: 'exp-1' });
+    await expect(getExpenseById('missing', database)).resolves.toBeNull();
+  });
+});
+
+describe('createExpense', () => {
+  it('derives month from date when missing and persists record', async () => {
+    const database = createMockDatabase();
+    vi.mocked(getCurrentIsoTimestamp).mockReturnValue('2024-05-15T00:00:00.000Z');
+
+    const created = await createExpense(
+      {
+        amountCents: 1_500,
+        date: '2024-05-05T00:00:00.000Z',
+        categoryId: 'groceries'
+      },
+      database
+    );
+
+    expect(created).toMatchObject({
+      id: 'generated-id',
+      month: getMonthKey('2024-05-05T00:00:00.000Z'),
+      createdAt: '2024-05-15T00:00:00.000Z',
+      updatedAt: '2024-05-15T00:00:00.000Z'
+    });
+  });
+});
+
+describe('updateExpense', () => {
+  it('recalculates month when date changes', async () => {
+    const database = createMockDatabase({ expenses: [groceryExpense] });
+    vi.mocked(getCurrentIsoTimestamp).mockReturnValue('2024-05-20T00:00:00.000Z');
+
+    const updated = await updateExpense(
+      'exp-1',
+      {
+        date: '2024-06-01T00:00:00.000Z'
+      },
+      database
+    );
+
+    expect(updated).toMatchObject({
+      month: '2024-06',
+      updatedAt: '2024-05-20T00:00:00.000Z'
+    });
+  });
+
+  it('throws when expense is missing', async () => {
+    const database = createMockDatabase();
+    await expect(updateExpense('missing', { amountCents: 1000 }, database)).rejects.toThrowError(
+      'Expense missing not found'
+    );
+  });
+});
+
+describe('deleteExpense', () => {
+  it('removes record by id', async () => {
+    const database = createMockDatabase({ expenses: [groceryExpense] });
+
+    await deleteExpense('exp-1', database);
+
+    await expect(listExpenses({}, database)).resolves.toHaveLength(0);
+  });
+});

--- a/src/services/__tests__/report.service.test.ts
+++ b/src/services/__tests__/report.service.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getBudgetVsActual, getSpendByCategory, getTrendOverTime } from '../report';
+import type { ExpenseRecord } from '@db/db';
+import { createMockDatabase } from '@test/utils/mockDatabase';
+import type { BudgetSnapshot } from '@domain/types';
+import * as budgetService from '../budget';
+
+describe('getBudgetVsActual', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('delegates to budget snapshots service', async () => {
+    const database = createMockDatabase();
+    const snapshot: BudgetSnapshot = {
+      categoryId: 'cat-1',
+      month: '2024-05',
+      limitCents: 30_000,
+      actualCents: 25_000,
+      availableCents: 5_000,
+      carryInCents: 0,
+      status: 'approaching'
+    };
+    const spy = vi.spyOn(budgetService, 'getBudgetSnapshots').mockResolvedValue([snapshot]);
+
+    const result = await getBudgetVsActual('2024-05', database);
+
+    expect(spy).toHaveBeenCalledWith('2024-05', database);
+    expect(result).toEqual([snapshot]);
+  });
+});
+
+describe('getSpendByCategory', () => {
+  it('aggregates totals per category and sorts descending', async () => {
+    const expenses: ExpenseRecord[] = [
+      {
+        id: 'exp-1',
+        amountCents: 10_000,
+        currency: 'EUR',
+        date: '2024-05-01T00:00:00.000Z',
+        month: '2024-05',
+        categoryId: 'cat-food',
+        createdAt: '2024-05-01T00:00:00.000Z',
+        updatedAt: '2024-05-01T00:00:00.000Z'
+      },
+      {
+        id: 'exp-2',
+        amountCents: 5_000,
+        currency: 'EUR',
+        date: '2024-05-02T00:00:00.000Z',
+        month: '2024-05',
+        categoryId: 'cat-food',
+        createdAt: '2024-05-02T00:00:00.000Z',
+        updatedAt: '2024-05-02T00:00:00.000Z'
+      },
+      {
+        id: 'exp-3',
+        amountCents: 20_000,
+        currency: 'EUR',
+        date: '2024-05-03T00:00:00.000Z',
+        month: '2024-05',
+        categoryId: 'cat-rent',
+        createdAt: '2024-05-03T00:00:00.000Z',
+        updatedAt: '2024-05-03T00:00:00.000Z'
+      }
+    ];
+    const database = createMockDatabase({ expenses });
+
+    const rows = await getSpendByCategory('2024-05', database);
+
+    expect(rows).toEqual([
+      { categoryId: 'cat-rent', month: '2024-05', totalCents: 20_000 },
+      { categoryId: 'cat-food', month: '2024-05', totalCents: 15_000 }
+    ]);
+  });
+});
+
+describe('getTrendOverTime', () => {
+  it('computes totals for each month in chronological order', async () => {
+    const expenses: ExpenseRecord[] = [
+      {
+        id: 'exp-jan',
+        amountCents: 10_000,
+        currency: 'EUR',
+        date: '2024-01-10T00:00:00.000Z',
+        month: '2024-01',
+        categoryId: 'cat-1',
+        createdAt: '2024-01-10T00:00:00.000Z',
+        updatedAt: '2024-01-10T00:00:00.000Z'
+      },
+      {
+        id: 'exp-feb',
+        amountCents: 8_000,
+        currency: 'EUR',
+        date: '2024-02-05T00:00:00.000Z',
+        month: '2024-02',
+        categoryId: 'cat-1',
+        createdAt: '2024-02-05T00:00:00.000Z',
+        updatedAt: '2024-02-05T00:00:00.000Z'
+      }
+    ];
+    const database = createMockDatabase({ expenses });
+
+    const trend = await getTrendOverTime({ startMonth: '2024-02', monthsBack: 1 }, database);
+
+    expect(trend).toEqual([
+      { month: '2024-01', totalCents: 10_000 },
+      { month: '2024-02', totalCents: 8_000 }
+    ]);
+  });
+});

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,1 +1,10 @@
-// Test setup placeholder – extend with shared mocks when needed.
+import { afterEach, vi } from 'vitest';
+import { cleanup } from '@testing-library/react';
+
+vi.mock('@paralleldrive/cuid2', () => ({
+  createId: vi.fn(() => 'generated-id')
+}));
+
+afterEach(() => {
+  cleanup();
+});

--- a/src/test/utils/mockDatabase.ts
+++ b/src/test/utils/mockDatabase.ts
@@ -1,0 +1,141 @@
+import type { BudgetRecord, CategoryRecord, ExpenseDatabase, ExpenseRecord, SettingRecord } from '@db/db';
+
+type IdentifiedRecord = { id: string } | { key: string };
+
+type Predicate<T> = (record: T) => boolean;
+
+interface MockCollection<T> {
+  toArray(): Promise<T[]>;
+  first(): Promise<T | undefined>;
+  and(filter: Predicate<T>): MockCollection<T>;
+  count(): Promise<number>;
+}
+
+interface WhereClause<T> {
+  equals(value: unknown): MockCollection<T>;
+}
+
+interface MockTable<T extends IdentifiedRecord> {
+  data: T[];
+  toCollection(): MockCollection<T>;
+  toArray(): Promise<T[]>;
+  where(field: keyof T): WhereClause<T>;
+  get(key: string): Promise<T | undefined>;
+  put(record: T): Promise<string>;
+  bulkPut(records: T[]): Promise<void>;
+  bulkDelete(keys: string[]): Promise<void>;
+  delete(key: string): Promise<void>;
+  clear(): Promise<void>;
+  count(): Promise<number>;
+}
+
+function getKey<T extends IdentifiedRecord>(record: T): string {
+  if ('id' in record) {
+    return record.id;
+  }
+  if ('key' in record) {
+    return record.key;
+  }
+  throw new Error('Unsupported record shape for mock table');
+}
+
+function createCollection<T extends IdentifiedRecord>(table: MockTable<T>, predicate: Predicate<T>): MockCollection<T> {
+  const applyFilter = (): T[] => table.data.filter(predicate);
+
+  return {
+    async toArray() {
+      return applyFilter().map((item) => ({ ...item }));
+    },
+    async first() {
+      const [firstItem] = applyFilter();
+      return firstItem ? { ...firstItem } : undefined;
+    },
+    and(nextPredicate) {
+      return createCollection(table, (record) => predicate(record) && nextPredicate(record));
+    },
+    async count() {
+      return applyFilter().length;
+    }
+  };
+}
+
+function createTable<T extends IdentifiedRecord>(initial: T[] = []): MockTable<T> {
+  const table: MockTable<T> = {
+    data: initial.map((item) => ({ ...item })),
+    toCollection() {
+      return createCollection(table, () => true);
+    },
+    async toArray() {
+      return this.data.map((item) => ({ ...item }));
+    },
+    where(field: keyof T): WhereClause<T> {
+      return {
+        equals(value: unknown) {
+          return createCollection(table, (record) => record[field] === value);
+        }
+      };
+    },
+    async get(key: string) {
+      const found = this.data.find((item) => getKey(item) === key);
+      return found ? { ...found } : undefined;
+    },
+    async put(record: T) {
+      const key = getKey(record);
+      const index = this.data.findIndex((item) => getKey(item) === key);
+      if (index >= 0) {
+        this.data[index] = { ...record };
+      } else {
+        this.data.push({ ...record });
+      }
+      return key;
+    },
+    async bulkPut(records: T[]) {
+      for (const record of records) {
+        await this.put(record);
+      }
+    },
+    async bulkDelete(keys: string[]) {
+      this.data = this.data.filter((record) => !keys.includes(getKey(record)));
+    },
+    async delete(key: string) {
+      this.data = this.data.filter((record) => getKey(record) !== key);
+    },
+    async clear() {
+      this.data = [];
+    },
+    async count() {
+      return this.data.length;
+    }
+  };
+
+  return table;
+}
+
+export interface MockDatabaseSeed {
+  categories?: CategoryRecord[];
+  expenses?: ExpenseRecord[];
+  budgets?: BudgetRecord[];
+  settings?: SettingRecord[];
+}
+
+export function createMockDatabase(seed: MockDatabaseSeed = {}): ExpenseDatabase {
+  const categories = createTable<CategoryRecord>(seed.categories);
+  const expenses = createTable<ExpenseRecord>(seed.expenses);
+  const budgets = createTable<BudgetRecord>(seed.budgets);
+  const settings = createTable<SettingRecord>(seed.settings);
+
+  const database = {
+    categories,
+    expenses,
+    budgets,
+    settings,
+    async transaction(_mode: string, ...operations: unknown[]) {
+      const callback = operations[operations.length - 1];
+      if (typeof callback === 'function') {
+        await callback();
+      }
+    }
+  } as unknown as ExpenseDatabase;
+
+  return database;
+}

--- a/src/utils/__tests__/useBudgetBadges.test.ts
+++ b/src/utils/__tests__/useBudgetBadges.test.ts
@@ -1,0 +1,61 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { useBudgetBadges } from '../useBudgetBadges';
+import type { BudgetSnapshot } from '@domain/types';
+import { getBudgetSnapshots } from '@services/budget';
+
+vi.mock('@services/budget', () => ({
+  getBudgetSnapshots: vi.fn()
+}));
+
+const mockSnapshots: BudgetSnapshot[] = [
+  {
+    categoryId: 'cat-1',
+    month: '2024-05',
+    limitCents: 30_000,
+    actualCents: 20_000,
+    availableCents: 10_000,
+    carryInCents: 0,
+    status: 'ok'
+  }
+];
+
+beforeEach(() => {
+  vi.mocked(getBudgetSnapshots).mockReset();
+});
+
+describe('useBudgetBadges', () => {
+  it('loads data on mount and exposes state helpers', async () => {
+    vi.mocked(getBudgetSnapshots).mockResolvedValue(mockSnapshots);
+
+    const { result } = renderHook(() => useBudgetBadges('2024-05'));
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(getBudgetSnapshots).toHaveBeenCalledWith('2024-05');
+    expect(result.current.badges).toEqual(mockSnapshots);
+    expect(result.current.error).toBeNull();
+
+    vi.mocked(getBudgetSnapshots).mockResolvedValue([{ ...mockSnapshots[0], actualCents: 25_000 }]);
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(result.current.badges[0].actualCents).toBe(25_000);
+  });
+
+  it('handles errors gracefully', async () => {
+    vi.mocked(getBudgetSnapshots).mockRejectedValue(new Error('Boom'));
+
+    const { result } = renderHook(() => useBudgetBadges('2024-05'));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.badges).toEqual([]);
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+});

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,37 @@
+# Testing Guide
+
+This project uses **Vitest** for unit tests and **Playwright** for browser automation. The goal is to keep local and CI executions identical.
+
+## Prerequisites
+
+- Node.js 20+
+- npm 9+ (or pnpm/yarn if you mirror the scripts)
+- For Playwright: download browsers once via `npx playwright install` (CI runs `npx playwright install --with-deps`).
+
+## Commands
+
+| Purpose | Command |
+| --- | --- |
+| Run unit tests with coverage | `npm run test:unit` |
+| Run unit tests in watch mode | `npm run test` |
+| Execute Playwright E2E suite | `npm run test:e2e` |
+| Open the Playwright UI | `npm run test:e2e -- --ui` |
+
+Unit tests rely on deterministic test doubles in `src/test/utils`. Playwright scenarios expect a built application served on port `4173` (configurable via `PLAYWRIGHT_BASE_URL`).
+
+## Test data preparation
+
+- `tests/fixtures/sample-backup.json` contains a minimal dataset that can be imported through the in-app JSON backup flow. This enables deterministic seeded states for manual or automated testing.
+- The `src/test/setup.ts` file centralises shared mocks (e.g., `createId`) and cleans up React trees after each test.
+
+## Continuous Integration
+
+The GitHub Actions workflow runs the following steps:
+
+1. `npm run lint`
+2. `npm run test:unit`
+3. `npm run build`
+4. `npx playwright install --with-deps`
+5. `npm run test:e2e`
+
+Refer to [`tests/plan.md`](./plan.md) for planned integration and end-to-end coverage.

--- a/tests/fixtures/sample-backup.json
+++ b/tests/fixtures/sample-backup.json
@@ -1,0 +1,41 @@
+{
+  "version": 1,
+  "exportedAt": "2024-05-01T00:00:00.000Z",
+  "categories": [
+    {
+      "id": "cat-groceries",
+      "name": "Groceries",
+      "color": "#ff8800",
+      "isHidden": false,
+      "createdAt": "2024-03-01T00:00:00.000Z",
+      "updatedAt": "2024-04-01T00:00:00.000Z"
+    }
+  ],
+  "budgets": [
+    {
+      "id": "budget-2024-05-groceries",
+      "month": "2024-05",
+      "categoryId": "cat-groceries",
+      "limitCents": 30000,
+      "carryOverPrev": true,
+      "createdAt": "2024-04-25T00:00:00.000Z",
+      "updatedAt": "2024-04-25T00:00:00.000Z"
+    }
+  ],
+  "expenses": [
+    {
+      "id": "exp-1",
+      "amountCents": 1250,
+      "currency": "EUR",
+      "date": "2024-05-02T10:15:00.000Z",
+      "month": "2024-05",
+      "categoryId": "cat-groceries",
+      "note": "Vegetables",
+      "createdAt": "2024-05-02T10:15:00.000Z",
+      "updatedAt": "2024-05-02T10:15:00.000Z"
+    }
+  ],
+  "settings": [
+    { "key": "currency", "value": "EUR" }
+  ]
+}

--- a/tests/plan.md
+++ b/tests/plan.md
@@ -1,0 +1,48 @@
+# Integration & E2E Test Plan
+
+This document outlines the target browser automation scenarios that complement the existing unit test suite. Each scenario maps to user-facing value and reuses the shared fixtures under `tests/fixtures/`.
+
+## Environments
+
+- **Local development**: `npm run dev` (Playwright auto-starts the dev server).
+- **CI**: Build once (`npm run build`) and serve via `npm run preview` (Playwright config handles this automatically).
+- All scenarios use `PLAYWRIGHT_BASE_URL` when specified; otherwise the default `http://127.0.0.1:4173` is used.
+
+## Scenarios
+
+### 1. Budget badge smoke test
+- Import `sample-backup.json` via the Settings page.
+- Navigate to the Budgets dashboard and assert that a badge for "Groceries" appears with carry-over enabled indicator.
+- Trigger a manual refresh (simulating the `useBudgetBadges` hook) and assert that loading feedback is shown and dismissed.
+
+### 2. Expense capture flow
+- Start from an empty state (clear database via UI or backup import).
+- Create a new category "Travel" and log an expense.
+- Verify the entry appears at the top of the list with correct amount, note, and computed month.
+
+### 3. Category management safeguards
+- Seed with `sample-backup.json`.
+- Attempt to delete the "Groceries" category, expect a blocking confirmation/error message.
+- Hide the category instead and confirm it no longer appears in quick selectors while remaining available for reports.
+
+### 4. Reports regression
+- With seeded data, open the Reports section.
+- Validate charts/tables for budget vs. actual, spend by category, and trend over time reflect the fixture totals.
+- Capture accessibility tree snapshots for comparison across runs.
+
+### 5. Backup round-trip
+- Export a backup file after making a change.
+- Clear data through the UI.
+- Re-import the exported backup and assert that categories, budgets, and expenses are restored (spot-check counts and totals).
+
+## Non-functional checks
+
+- Run Playwright in Chromium, Firefox, and WebKit on CI (already configured in `playwright.config.ts`).
+- Capture traces on first retry to aid debugging (`trace: 'on-first-retry'`).
+- Surface test artifacts via the default Playwright HTML report (CI stores as workflow artifact).
+
+## Future enhancements
+
+- Add visual regression coverage for budget badge states.
+- Extend the backup round-trip to compare JSON payloads byte-for-byte.
+- Integrate axe-core checks for accessibility within each flow.

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -18,7 +18,8 @@
       "@pages/*": ["src/pages/*"],
       "@services/*": ["src/services/*"],
       "@styles/*": ["src/styles/*"],
-      "@utils/*": ["src/utils/*"]
+      "@utils/*": ["src/utils/*"],
+      "@test/*": ["src/test/*"]
     }
   },
   "include": ["vite.config.ts", "src"],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,12 +12,18 @@ export default defineConfig({
       '@pages': '/src/pages',
       '@services': '/src/services',
       '@styles': '/src/styles',
-      '@utils': '/src/utils'
+      '@utils': '/src/utils',
+      '@test': '/src/test'
     }
   },
   test: {
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],
-    globals: true
+    globals: true,
+    reporters: process.env.CI ? ['default', 'junit'] : 'default',
+    coverage: {
+      reporter: ['text', 'lcov'],
+      include: ['src/services/**/*.ts', 'src/utils/**/*.ts']
+    }
   }
 });


### PR DESCRIPTION
## Summary
- add comprehensive unit tests for all service modules and the useBudgetBadges hook with shared mock database utilities
- document the integration/e2e strategy, Playwright configuration, and reusable fixtures for consistent local/CI execution
- add a CI workflow plus documentation updates for README and RELEASING, including a status badge and release checklist additions

## Testing
- not run (sandbox npm registry returned 403 for dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68d95e7bf748832694d91d0094e6f5b7