### PR TITLE
Refactor Log page table with inline editing and undo stack

### DIFF
--- a/src/pages/Log/index.test.tsx
+++ b/src/pages/Log/index.test.tsx
@@ -1,0 +1,193 @@
+import '@testing-library/jest-dom/vitest';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { listCategories } from '@services/category';
+import { createExpense, deleteExpense, listExpenses, updateExpense } from '@services/expense';
+import type { Category, Expense } from '@domain/types';
+
+import { LogPage } from './index';
+
+vi.mock('@services/category', () => ({
+  listCategories: vi.fn()
+}));
+
+vi.mock('@services/expense', () => ({
+  listExpenses: vi.fn(),
+  createExpense: vi.fn(),
+  updateExpense: vi.fn(),
+  deleteExpense: vi.fn()
+}));
+
+const listCategoriesMock = vi.mocked(listCategories);
+const listExpensesMock = vi.mocked(listExpenses);
+const createExpenseMock = vi.mocked(createExpense);
+const updateExpenseMock = vi.mocked(updateExpense);
+const deleteExpenseMock = vi.mocked(deleteExpense);
+
+const categories: Category[] = [
+  {
+    id: 'cat-1',
+    name: 'Food',
+    color: '#ff0000',
+    isHidden: false,
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z'
+  },
+  {
+    id: 'cat-2',
+    name: 'Home',
+    color: '#00ff00',
+    isHidden: false,
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z'
+  }
+];
+
+const baseExpense: Expense = {
+  id: 'expense-1',
+  amountCents: 1250,
+  currency: 'EUR',
+  date: '2024-05-01T00:00:00.000Z',
+  month: '2024-05',
+  categoryId: 'cat-1',
+  note: 'Groceries',
+  createdAt: '2024-05-01T12:00:00.000Z',
+  updatedAt: '2024-05-01T12:00:00.000Z'
+};
+
+const secondExpense: Expense = {
+  id: 'expense-2',
+  amountCents: 2500,
+  currency: 'EUR',
+  date: '2024-05-03T00:00:00.000Z',
+  month: '2024-05',
+  categoryId: 'cat-2',
+  note: 'Utilities',
+  createdAt: '2024-05-03T12:00:00.000Z',
+  updatedAt: '2024-05-03T12:00:00.000Z'
+};
+
+function cloneExpense(expense: Expense): Expense {
+  return JSON.parse(JSON.stringify(expense));
+}
+
+let currentExpenses: Expense[] = [];
+let nextExpenseId = 3;
+let createdExpenseIds: string[] = [];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  currentExpenses = [cloneExpense(baseExpense), cloneExpense(secondExpense)];
+  nextExpenseId = 3;
+  createdExpenseIds = [];
+
+  listCategoriesMock.mockResolvedValue(categories);
+  listExpensesMock.mockImplementation(async () => currentExpenses.map(cloneExpense));
+  createExpenseMock.mockImplementation(async (input: any) => {
+    const id = input.id ?? `expense-${nextExpenseId++}`;
+    const created: Expense = {
+      id,
+      amountCents: input.amountCents,
+      currency: 'EUR',
+      date: input.date,
+      month: input.month,
+      categoryId: input.categoryId,
+      note: input.note,
+      createdAt: '2024-05-05T12:00:00.000Z',
+      updatedAt: '2024-05-05T12:00:00.000Z'
+    };
+    currentExpenses = [created, ...currentExpenses.filter((expense) => expense.id !== id)];
+    createdExpenseIds.push(id);
+    return cloneExpense(created);
+  });
+  updateExpenseMock.mockImplementation(async (id: string, patch: any) => {
+    const existing = currentExpenses.find((expense) => expense.id === id);
+    if (!existing) {
+      throw new Error('Expense not found');
+    }
+    const updated: Expense = {
+      ...existing,
+      ...patch,
+      updatedAt: '2024-05-06T12:00:00.000Z'
+    };
+    currentExpenses = currentExpenses.map((expense) => (expense.id === id ? updated : expense));
+    return cloneExpense(updated);
+  });
+  deleteExpenseMock.mockImplementation(async (id: string) => {
+    currentExpenses = currentExpenses.filter((expense) => expense.id !== id);
+  });
+});
+
+describe('LogPage table interactions', () => {
+  it('supports keyboard navigation, inline editing, and delete shortcut', async () => {
+    const user = userEvent.setup();
+    render(<LogPage />);
+
+    await waitFor(() => expect(listExpensesMock).toHaveBeenCalled());
+    const tableRegion = await screen.findByTestId('expense-table');
+    const rows = within(tableRegion).getAllByRole('row');
+    const firstDataRow = rows[1];
+    firstDataRow.focus();
+    expect(document.activeElement).toBe(firstDataRow);
+
+    await user.keyboard('{ArrowDown}');
+    const secondDataRow = rows[2];
+    expect(document.activeElement).toBe(secondDataRow);
+
+    await user.keyboard('e');
+    const amountInput = within(secondDataRow).getByLabelText(/Amount for/i);
+    expect(amountInput).toBeInTheDocument();
+
+    await user.click(within(secondDataRow).getByRole('button', { name: /Cancel/i }));
+    await waitFor(() => expect(document.activeElement).toBe(secondDataRow));
+
+    await user.keyboard('{Delete}');
+    expect(
+      await screen.findByRole('alertdialog', {
+        name: /Delete expense/i
+      })
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /Cancel/ }));
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument());
+  });
+
+  it('queues multi-step undo actions and applies them in order', async () => {
+    const user = userEvent.setup();
+    render(<LogPage />);
+
+    await waitFor(() => expect(listExpensesMock).toHaveBeenCalled());
+    const amountInput = await screen.findByRole('textbox', { name: /Amount/i });
+    const dateInput = await screen.findByLabelText('Date', { selector: 'input' });
+    const noteInput = await screen.findByLabelText('Note', { selector: 'textarea' });
+
+    fireEvent.input(amountInput, { target: { value: '10.00' } });
+    fireEvent.input(dateInput, { target: { value: '2024-05-05' } });
+    fireEvent.input(noteInput, { target: { value: 'First stack entry' } });
+    await user.click(screen.getByRole('button', { name: 'Add expense' }));
+    await waitFor(() => expect(createExpenseMock).toHaveBeenCalledTimes(1));
+    expect(createdExpenseIds).toHaveLength(1);
+
+    fireEvent.input(amountInput, { target: { value: '20.00' } });
+    fireEvent.input(dateInput, { target: { value: '2024-05-06' } });
+    fireEvent.input(noteInput, { target: { value: 'Second stack entry' } });
+    await user.click(screen.getByRole('button', { name: 'Add expense' }));
+    await waitFor(() => expect(createExpenseMock).toHaveBeenCalledTimes(2));
+    expect(createdExpenseIds).toHaveLength(2);
+
+    const undoBanner = await screen.findByRole('status');
+    expect(undoBanner).toHaveTextContent('Expense saved.');
+    expect(undoBanner).toHaveTextContent('(1 more)');
+
+    await user.click(screen.getByRole('button', { name: 'Undo' }));
+    await waitFor(() => expect(deleteExpenseMock).toHaveBeenCalledWith(createdExpenseIds[1]));
+    expect(await screen.findByRole('status')).toHaveTextContent('Expense saved.');
+
+    await user.click(screen.getByRole('button', { name: 'Undo' }));
+    await waitFor(() => expect(deleteExpenseMock).toHaveBeenCalledWith(createdExpenseIds[0]));
+
+    await waitFor(() => expect(screen.queryByRole('status')).not.toBeInTheDocument());
+  });
+});

--- a/src/pages/Log/index.tsx
+++ b/src/pages/Log/index.tsx
@@ -1,5 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { format } from 'date-fns';
+import {
+  createColumnHelper,
+  flexRender,
+  getCoreRowModel,
+  useReactTable
+} from '@tanstack/react-table';
 
 import { ConfirmDialog } from '@components/ConfirmDialog';
 import { Money } from '@components/Money';
@@ -24,6 +30,15 @@ interface UndoState {
   handler: () => Promise<void>;
 }
 
+interface EditableRowState {
+  amount: string;
+  date: string;
+  categoryId: string;
+  note: string;
+}
+
+const columnHelper = createColumnHelper<Expense>();
+
 function buildInitialForm(categories: Category[]): ExpenseFormState {
   const today = format(new Date(), 'yyyy-MM-dd');
   const defaultCategory = categories[0]?.id ?? '';
@@ -41,11 +56,19 @@ export function LogPage(): JSX.Element {
   const [formState, setFormState] = useState<ExpenseFormState>(() => buildInitialForm([]));
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [feedback, setFeedback] = useState<string | null>(null);
-  const [undoState, setUndoState] = useState<UndoState | null>(null);
+  const [undoStack, setUndoStack] = useState<UndoState[]>([]);
   const [pendingDelete, setPendingDelete] = useState<Expense | null>(null);
-  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editingRows, setEditingRows] = useState<Record<string, EditableRowState>>({});
+  const [savingRows, setSavingRows] = useState<Record<string, boolean>>({});
+  const [focusedRowId, setFocusedRowId] = useState<string | null>(null);
 
   const amountInputRef = useRef<HTMLInputElement>(null);
+  const rowRefs = useRef<Map<string, HTMLTableRowElement>>(new Map());
+  const undoTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const pushUndo = useCallback((undo: UndoState) => {
+    setUndoStack((previous) => [...previous, undo]);
+  }, []);
 
   useEffect(() => {
     let active = true;
@@ -92,6 +115,24 @@ export function LogPage(): JSX.Element {
   }, [loadExpenses]);
 
   useEffect(() => {
+    if (undoTimerRef.current) {
+      clearTimeout(undoTimerRef.current);
+    }
+    if (undoStack.length === 0) {
+      return;
+    }
+    undoTimerRef.current = setTimeout(() => {
+      setUndoStack((previous) => previous.slice(0, -1));
+    }, 8000);
+
+    return () => {
+      if (undoTimerRef.current) {
+        clearTimeout(undoTimerRef.current);
+      }
+    };
+  }, [undoStack]);
+
+  useEffect(() => {
     const handler = (event: KeyboardEvent) => {
       if (event.key.toLowerCase() === 'n' && !event.defaultPrevented) {
         const target = event.target as HTMLElement | null;
@@ -109,20 +150,203 @@ export function LogPage(): JSX.Element {
     };
   }, []);
 
-  const totalForMonth = useMemo(() => {
-    return expenses.reduce((sum, expense) => sum + expense.amountCents, 0);
+  useEffect(() => {
+    if (expenses.length === 0) {
+      setFocusedRowId(null);
+      return;
+    }
+    setFocusedRowId((previous) => {
+      if (previous && expenses.some((expense) => expense.id === previous)) {
+        return previous;
+      }
+      return expenses[0].id;
+    });
   }, [expenses]);
 
-  const handleFormChange: React.ChangeEventHandler<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement> = (
-    event
-  ) => {
+  const registerRowRef = useCallback((rowId: string, element: HTMLTableRowElement | null) => {
+    if (element) {
+      rowRefs.current.set(rowId, element);
+    } else {
+      rowRefs.current.delete(rowId);
+    }
+  }, []);
+
+  const focusRow = useCallback((rowId: string) => {
+    const row = rowRefs.current.get(rowId);
+    if (row && document.activeElement !== row) {
+      row.focus();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!focusedRowId) {
+      return;
+    }
+    if (editingRows[focusedRowId]) {
+      return;
+    }
+    focusRow(focusedRowId);
+  }, [focusedRowId, editingRows, focusRow]);
+
+  const focusRowEditor = useCallback((rowId: string) => {
+    requestAnimationFrame(() => {
+      const row = rowRefs.current.get(rowId);
+      if (!row) {
+        return;
+      }
+      const control = row.querySelector<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>(
+        'input, select, textarea'
+      );
+      control?.focus();
+    });
+  }, []);
+
+  const stopEditingRow = useCallback(
+    (rowId: string) => {
+      setEditingRows((previous) => {
+        if (!previous[rowId]) {
+          return previous;
+        }
+        const next = { ...previous };
+        delete next[rowId];
+        return next;
+      });
+      setSavingRows((previous) => {
+        if (!previous[rowId]) {
+          return previous;
+        }
+        const next = { ...previous };
+        delete next[rowId];
+        return next;
+      });
+      setFocusedRowId(rowId);
+      focusRow(rowId);
+    },
+    [focusRow]
+  );
+
+  const handleInlineChange = useCallback((rowId: string, field: keyof EditableRowState, value: string) => {
+    setEditingRows((previous) => {
+      const existing = previous[rowId];
+      if (!existing) {
+        return previous;
+      }
+      return {
+        ...previous,
+        [rowId]: { ...existing, [field]: value }
+      };
+    });
+  }, []);
+
+  const handleInlineEdit = useCallback(
+    (expense: Expense) => {
+      setEditingRows((previous) => {
+        if (previous[expense.id]) {
+          return previous;
+        }
+        return {
+          ...previous,
+          [expense.id]: {
+            amount: (expense.amountCents / 100).toFixed(2),
+            date: expense.date.slice(0, 10),
+            categoryId: expense.categoryId,
+            note: expense.note ?? ''
+          }
+        };
+      });
+      setFocusedRowId(expense.id);
+      window.setTimeout(() => {
+        focusRowEditor(expense.id);
+      }, 0);
+    },
+    [focusRowEditor]
+  );
+
+  const handleInlineCancel = useCallback(
+    (rowId: string) => {
+      stopEditingRow(rowId);
+    },
+    [stopEditingRow]
+  );
+
+  const handleInlineSave = useCallback(
+    async (rowId: string) => {
+      const draft = editingRows[rowId];
+      if (!draft) {
+        return;
+      }
+      const current = expenses.find((expense) => expense.id === rowId);
+      if (!current) {
+        setFeedback('This expense no longer exists.');
+        stopEditingRow(rowId);
+        return;
+      }
+      if (!draft.categoryId) {
+        setFeedback('Pick a category to log this expense.');
+        return;
+      }
+      const amountValue = draft.amount.trim();
+      if (amountValue === '') {
+        setFeedback('Enter an amount in euro cents.');
+        return;
+      }
+      try {
+        setSavingRows((previous) => ({ ...previous, [rowId]: true }));
+        const amountCents = parseEuroToCents(amountValue);
+        const isoDate = new Date(`${draft.date}T00:00:00`).toISOString();
+        const monthKey = getMonthKey(isoDate);
+        await updateExpense(rowId, {
+          amountCents,
+          date: isoDate,
+          month: monthKey,
+          categoryId: draft.categoryId,
+          note: draft.note.trim() === '' ? undefined : draft.note.trim()
+        });
+        setFeedback('Expense updated. Nice catch.');
+        pushUndo({
+          message: 'Expense updated.',
+          actionLabel: 'Undo',
+          handler: async () => {
+            await updateExpense(rowId, {
+              amountCents: current.amountCents,
+              date: current.date,
+              month: current.month,
+              categoryId: current.categoryId,
+              note: current.note
+            });
+            setFeedback('Reverted your last change.');
+          }
+        });
+        stopEditingRow(rowId);
+        if (monthKey !== month) {
+          setMonth(monthKey);
+        } else {
+          await loadExpenses();
+        }
+      } catch (cause) {
+        const message =
+          cause instanceof Error ? cause.message : 'Couldn’t save. Check the amount and try again.';
+        setFeedback(message);
+      } finally {
+        setSavingRows((previous) => {
+          const next = { ...previous };
+          delete next[rowId];
+          return next;
+        });
+      }
+    },
+    [editingRows, expenses, loadExpenses, month, pushUndo, stopEditingRow]
+  );
+
+  const handleFormChange: React.ChangeEventHandler<
+    HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement
+  > = (event) => {
     const { name, value } = event.target;
     setFormState((prev) => ({ ...prev, [name]: value }));
   };
 
   const resetForm = useCallback(() => {
     setFormState(buildInitialForm(categories));
-    setEditingId(null);
     amountInputRef.current?.focus();
   }, [categories]);
 
@@ -152,43 +376,16 @@ export function LogPage(): JSX.Element {
         note: formState.note.trim() === '' ? undefined : formState.note.trim()
       };
 
-      if (editingId) {
-        const current = expenses.find((item) => item.id === editingId);
-        if (!current) {
-          setFeedback('This expense no longer exists.');
-          setEditingId(null);
-        } else {
-          await updateExpense(editingId, basePayload);
-          setFeedback('Expense updated. Nice catch.');
-          setUndoState({
-            message: 'Expense updated.',
-            actionLabel: 'Undo',
-            handler: async () => {
-              await updateExpense(editingId, {
-                amountCents: current.amountCents,
-                date: current.date,
-                month: current.month,
-                categoryId: current.categoryId,
-                note: current.note
-              });
-              setFeedback('Reverted your last change.');
-              await loadExpenses();
-            }
-          });
+      const expense = await createExpense(basePayload);
+      setFeedback('Expense saved. You’re on track.');
+      pushUndo({
+        message: 'Expense saved.',
+        actionLabel: 'Undo',
+        handler: async () => {
+          await deleteExpense(expense.id);
+          setFeedback('Expense removed.');
         }
-      } else {
-        const expense = await createExpense(basePayload);
-        setFeedback('Expense saved. You’re on track.');
-        setUndoState({
-          message: 'Expense saved.',
-          actionLabel: 'Undo',
-          handler: async () => {
-            await deleteExpense(expense.id);
-            setFeedback('Expense removed.');
-            await loadExpenses();
-          }
-        });
-      }
+      });
 
       resetForm();
       if (monthKey !== month) {
@@ -197,29 +394,20 @@ export function LogPage(): JSX.Element {
         await loadExpenses();
       }
     } catch (cause) {
-      const message = cause instanceof Error ? cause.message : 'Couldn’t save. Check the amount and try again.';
+      const message =
+        cause instanceof Error ? cause.message : 'Couldn’t save. Check the amount and try again.';
       setFeedback(message);
     } finally {
       setIsSubmitting(false);
     }
   };
 
-  const handleEdit = (expense: Expense) => {
-    setEditingId(expense.id);
-    setFormState({
-      amount: (expense.amountCents / 100).toFixed(2),
-      date: expense.date.slice(0, 10),
-      categoryId: expense.categoryId,
-      note: expense.note ?? ''
-    });
-    amountInputRef.current?.focus();
-  };
-
-  const handleDelete = (expense: Expense) => {
+  const handleDelete = useCallback((expense: Expense) => {
     setPendingDelete(expense);
-  };
+    setFocusedRowId(expense.id);
+  }, []);
 
-  const confirmDelete = async () => {
+  const confirmDelete = useCallback(async () => {
     if (!pendingDelete) {
       return;
     }
@@ -227,7 +415,7 @@ export function LogPage(): JSX.Element {
       await deleteExpense(pendingDelete.id);
       setFeedback('Expense deleted.');
       const deletedExpense = pendingDelete;
-      setUndoState({
+      pushUndo({
         message: 'Expense deleted.',
         actionLabel: 'Undo',
         handler: async () => {
@@ -240,31 +428,265 @@ export function LogPage(): JSX.Element {
             note: deletedExpense.note
           });
           setFeedback('Expense restored.');
-          await loadExpenses();
         }
       });
       await loadExpenses();
     } catch (cause) {
-      const message = cause instanceof Error ? cause.message : 'Couldn’t delete this expense. Try again.';
+      const message =
+        cause instanceof Error ? cause.message : 'Couldn’t delete this expense. Try again.';
       setFeedback(message);
     } finally {
       setPendingDelete(null);
     }
-  };
+  }, [pendingDelete, pushUndo, loadExpenses]);
 
-  const cancelDelete = () => {
+  const cancelDelete = useCallback(() => {
+    if (pendingDelete) {
+      focusRow(pendingDelete.id);
+    }
     setPendingDelete(null);
-  };
+  }, [pendingDelete, focusRow]);
 
-  const applyUndo = async () => {
-    if (!undoState) {
+  const handleTableKeyDown: React.KeyboardEventHandler<HTMLDivElement> = useCallback(
+    (event) => {
+      const target = event.target as HTMLElement;
+      const tagName = target.tagName;
+      if (['INPUT', 'TEXTAREA', 'SELECT', 'BUTTON'].includes(tagName)) {
+        return;
+      }
+      const currentRowElement = target.closest<HTMLTableRowElement>('[data-row-id]');
+      const rowElement = currentRowElement ?? (focusedRowId ? rowRefs.current.get(focusedRowId) ?? null : null);
+      if (!rowElement) {
+        return;
+      }
+      const rowId = rowElement.dataset.rowId;
+      if (!rowId) {
+        return;
+      }
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        const index = expenses.findIndex((expense) => expense.id === rowId);
+        if (index >= 0 && index < expenses.length - 1) {
+          const nextExpense = expenses[index + 1];
+          setFocusedRowId(nextExpense.id);
+          focusRow(nextExpense.id);
+        }
+        return;
+      }
+      if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        const index = expenses.findIndex((expense) => expense.id === rowId);
+        if (index > 0) {
+          const previousExpense = expenses[index - 1];
+          setFocusedRowId(previousExpense.id);
+          focusRow(previousExpense.id);
+        }
+        return;
+      }
+      if (event.key.toLowerCase() === 'e') {
+        if (editingRows[rowId]) {
+          return;
+        }
+        event.preventDefault();
+        const expense = expenses.find((item) => item.id === rowId);
+        if (expense) {
+          handleInlineEdit(expense);
+        }
+        return;
+      }
+      if (event.key === 'Delete') {
+        event.preventDefault();
+        const expense = expenses.find((item) => item.id === rowId);
+        if (expense) {
+          handleDelete(expense);
+        }
+      }
+    },
+    [editingRows, expenses, focusRow, focusedRowId, handleDelete, handleInlineEdit]
+  );
+
+  const totalForMonth = useMemo(() => {
+    return expenses.reduce((sum, expense) => sum + expense.amountCents, 0);
+  }, [expenses]);
+
+  const columns = useMemo(
+    () => [
+      columnHelper.display({
+        id: 'date',
+        header: () => 'Date',
+        cell: ({ row }) => {
+          const expense = row.original;
+          const editState = editingRows[expense.id];
+          if (editState) {
+            return (
+              <input
+                className="form__input"
+                type="date"
+                value={editState.date}
+                onChange={(event) => handleInlineChange(expense.id, 'date', event.target.value)}
+                aria-label={`Date for ${format(new Date(expense.date), 'dd MMM yyyy')}`}
+              />
+            );
+          }
+          return format(new Date(expense.date), 'dd MMM yyyy');
+        }
+      }),
+      columnHelper.display({
+        id: 'category',
+        header: () => 'Category',
+        cell: ({ row }) => {
+          const expense = row.original;
+          const editState = editingRows[expense.id];
+          const categoryName =
+            categories.find((category) => category.id === expense.categoryId)?.name ?? 'Unknown';
+          if (editState) {
+            return (
+              <select
+                className="form__input"
+                value={editState.categoryId}
+                onChange={(event) => handleInlineChange(expense.id, 'categoryId', event.target.value)}
+                aria-label={`Category for ${categoryName}`}
+              >
+                <option value="" disabled>
+                  Choose a category
+                </option>
+                {categories.map((category) => (
+                  <option key={category.id} value={category.id}>
+                    {category.name}
+                  </option>
+                ))}
+              </select>
+            );
+          }
+          return categoryName;
+        }
+      }),
+      columnHelper.display({
+        id: 'amount',
+        header: () => 'Amount',
+        cell: ({ row }) => {
+          const expense = row.original;
+          const editState = editingRows[expense.id];
+          const categoryName =
+            categories.find((category) => category.id === expense.categoryId)?.name ?? 'expense';
+          if (editState) {
+            return (
+              <input
+                className="form__input"
+                value={editState.amount}
+                onChange={(event) => handleInlineChange(expense.id, 'amount', event.target.value)}
+                inputMode="decimal"
+                aria-label={`Amount for ${categoryName}`}
+              />
+            );
+          }
+          return <Money amountCents={expense.amountCents} />;
+        }
+      }),
+      columnHelper.display({
+        id: 'note',
+        header: () => 'Note',
+        cell: ({ row }) => {
+          const expense = row.original;
+          const editState = editingRows[expense.id];
+          if (editState) {
+            return (
+              <textarea
+                className="form__input"
+                value={editState.note}
+                onChange={(event) => handleInlineChange(expense.id, 'note', event.target.value)}
+                rows={2}
+                maxLength={500}
+                aria-label="Note"
+              />
+            );
+          }
+          return expense.note ?? '—';
+        }
+      }),
+      columnHelper.display({
+        id: 'actions',
+        header: () => 'Actions',
+        cell: ({ row }) => {
+          const expense = row.original;
+          const editState = editingRows[expense.id];
+          const isSaving = Boolean(savingRows[expense.id]);
+          if (editState) {
+            return (
+              <div className="table__actions">
+                <button
+                  type="button"
+                  className="button button--primary"
+                  onClick={() => handleInlineSave(expense.id)}
+                  disabled={isSaving}
+                >
+                  Save
+                </button>
+                <button
+                  type="button"
+                  className="button button--ghost"
+                  onClick={() => handleInlineCancel(expense.id)}
+                  disabled={isSaving}
+                >
+                  Cancel
+                </button>
+              </div>
+            );
+          }
+          const categoryName =
+            categories.find((category) => category.id === expense.categoryId)?.name ?? 'expense';
+          return (
+            <div className="table__actions">
+              <button
+                type="button"
+                className="link-button"
+                onClick={() => handleInlineEdit(expense)}
+                aria-label={`Edit expense from ${categoryName}`}
+              >
+                Edit
+              </button>
+              <button
+                type="button"
+                className="link-button link-button--danger"
+                onClick={() => handleDelete(expense)}
+                aria-label={`Delete expense from ${categoryName}`}
+              >
+                Delete
+              </button>
+            </div>
+          );
+        }
+      })
+    ],
+    [categories, editingRows, handleDelete, handleInlineCancel, handleInlineChange, handleInlineEdit, handleInlineSave, savingRows]
+  );
+
+  const table = useReactTable({
+    data: expenses,
+    columns,
+    getCoreRowModel: getCoreRowModel()
+  });
+
+  const latestUndo = undoStack[undoStack.length - 1] ?? null;
+  const pendingUndoCount = undoStack.length > 0 ? undoStack.length - 1 : 0;
+
+  const applyUndo = useCallback(async () => {
+    let latestAction: UndoState | undefined;
+    setUndoStack((previous) => {
+      if (previous.length === 0) {
+        latestAction = undefined;
+        return previous;
+      }
+      const next = [...previous];
+      latestAction = next.pop();
+      return next;
+    });
+    if (!latestAction) {
       return;
     }
-    const currentUndo = undoState;
-    setUndoState(null);
-    await currentUndo.handler();
+    await latestAction.handler();
     await loadExpenses();
-  };
+  }, [loadExpenses]);
 
   return (
     <article id="panel-log" role="tabpanel" aria-labelledby="tab-log" className="page">
@@ -343,20 +765,12 @@ export function LogPage(): JSX.Element {
             <div className="form__actions">
               {feedback ? <p className="form__feedback">{feedback}</p> : null}
               <div className="form__buttons">
-                {editingId ? (
-                  <>
-                    <button type="submit" className="button button--primary" disabled={isSubmitting}>
-                      Save changes
-                    </button>
-                    <button type="button" className="button button--ghost" onClick={resetForm}>
-                      Cancel
-                    </button>
-                  </>
-                ) : (
-                  <button type="submit" className="button button--primary" disabled={isSubmitting}>
-                    Add expense
-                  </button>
-                )}
+                <button type="submit" className="button button--primary" disabled={isSubmitting}>
+                  Add expense
+                </button>
+                <button type="button" className="button button--ghost" onClick={resetForm}>
+                  Clear
+                </button>
               </div>
             </div>
           </form>
@@ -406,47 +820,51 @@ export function LogPage(): JSX.Element {
           ) : expenses.length === 0 ? (
             <p className="card__empty">No expenses yet. Log your first one to see your month take shape.</p>
           ) : (
-            <div className="table-wrapper" role="region" aria-live="polite">
+            <div
+              className="table-wrapper"
+              role="region"
+              aria-live="polite"
+              data-testid="expense-table"
+              onKeyDown={handleTableKeyDown}
+            >
               <table className="table">
                 <thead>
-                  <tr>
-                    <th scope="col">Date</th>
-                    <th scope="col">Category</th>
-                    <th scope="col">Amount</th>
-                    <th scope="col">Note</th>
-                    <th scope="col" className="table__actions">Actions</th>
-                  </tr>
+                  {table.getHeaderGroups().map((headerGroup) => (
+                    <tr key={headerGroup.id}>
+                      {headerGroup.headers.map((header) => (
+                        <th
+                          key={header.id}
+                          scope="col"
+                          className={header.column.id === 'actions' ? 'table__actions' : undefined}
+                        >
+                          {header.isPlaceholder
+                            ? null
+                            : flexRender(header.column.columnDef.header, header.getContext())}
+                        </th>
+                      ))}
+                    </tr>
+                  ))}
                 </thead>
                 <tbody>
-                  {expenses.map((expense) => {
-                    const categoryName = categories.find((category) => category.id === expense.categoryId)?.name ??
-                      'Unknown';
+                  {table.getRowModel().rows.map((row) => {
+                    const expense = row.original;
+                    const isEditing = Boolean(editingRows[expense.id]);
                     return (
-                      <tr key={expense.id}>
-                        <td>{format(new Date(expense.date), 'dd MMM yyyy')}</td>
-                        <td>{categoryName}</td>
-                        <td>
-                          <Money amountCents={expense.amountCents} />
-                        </td>
-                        <td>{expense.note ?? '—'}</td>
-                        <td className="table__actions">
-                          <button
-                            type="button"
-                            className="link-button"
-                            onClick={() => handleEdit(expense)}
-                            aria-label={`Edit expense from ${categoryName}`}
+                      <tr
+                        key={row.id}
+                        data-row-id={expense.id}
+                        tabIndex={isEditing ? -1 : 0}
+                        ref={(element) => registerRowRef(expense.id, element)}
+                        onFocus={() => setFocusedRowId(expense.id)}
+                      >
+                        {row.getVisibleCells().map((cell) => (
+                          <td
+                            key={cell.id}
+                            className={cell.column.id === 'actions' ? 'table__actions' : undefined}
                           >
-                            Edit
-                          </button>
-                          <button
-                            type="button"
-                            className="link-button link-button--danger"
-                            onClick={() => handleDelete(expense)}
-                            aria-label={`Delete expense from ${categoryName}`}
-                          >
-                            Delete
-                          </button>
-                        </td>
+                            {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                          </td>
+                        ))}
                       </tr>
                     );
                   })}
@@ -456,11 +874,14 @@ export function LogPage(): JSX.Element {
           )}
         </section>
 
-        {undoState ? (
+        {latestUndo ? (
           <div className="undo-banner" role="status">
-            <span>{undoState.message}</span>
+            <span>
+              {latestUndo.message}
+              {pendingUndoCount > 0 ? ` (${pendingUndoCount} more)` : ''}
+            </span>
             <button type="button" className="button button--ghost" onClick={applyUndo}>
-              {undoState.actionLabel}
+              {latestUndo.actionLabel}
             </button>
           </div>
         ) : null}


### PR DESCRIPTION
## Summary
- replace the expenses table implementation with a TanStack Table setup that supports per-row inline editing and keyboard focus management
- add keyboard handlers for row focus, inline edit toggling, and delete confirmation shortcuts
- convert the single undo state into a stack with auto-dismiss and expose undo actions through the banner
- cover the new behaviors with LogPage interaction tests for keyboard navigation and stacked undo flow

## Testing
- npm test -- --run *(fails: vitest binary missing in environment due to install restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68da1d7776908326b68c9fd107f3e8e1