### PR TITLE
Add regression tests and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 8
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Test
+        run: pnpm test --runInBand

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Expense Tracker (Desktop, EUR, English)
 
+[![CI](https://github.com/your-org/simple-ledger/actions/workflows/ci.yml/badge.svg)](https://github.com/your-org/simple-ledger/actions/workflows/ci.yml)
+
 Manual expense logging with monthly category budgets and clear charts. Local-first (IndexedDB), no accounts.
 
 ## Features (MVP)
@@ -30,6 +32,10 @@ When the development environment runs inside a sandbox or remote container, expo
 - `npm run lint` — run ESLint against TypeScript/React sources
 - `npm run test` — execute unit tests in watch mode with Vitest
 
+## Continuous integration
+
+The GitHub Actions workflow defined in `.github/workflows/ci.yml` installs dependencies with `pnpm`, runs the lint checks, and executes the Vitest suite (`pnpm test --runInBand`) for every push and pull request targeting `main`.
+
 ## Tech stack
 - React 18 + TypeScript
 - Vite 5 build tooling
@@ -57,7 +63,6 @@ Additional directories of note:
 
 ## Current limitations
 - Tab content is placeholder-only; Stage 3 will add the real forms, tables, and dashboards referenced in each page description.
-- Automated tests are not yet implemented even though the tooling is scaffolded (`npm run test` is reserved for future work).
 
 ## Contributing
 See `CONTRIBUTING.md`. Code of Conduct: `CODE_OF_CONDUCT.md`.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
-    "test": "vitest"
+    "test": "node ./scripts/run-tests.mjs"
   },
   "dependencies": {
     "@paralleldrive/cuid2": "^2.2.2",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+const args = process.argv.slice(2);
+const filteredArgs = args.filter((arg) => arg !== '--runInBand');
+const require = createRequire(import.meta.url);
+const vitestPackagePath = require.resolve('vitest/package.json');
+const cliPath = path.join(path.dirname(vitestPackagePath), 'dist/cli.js');
+
+const child = spawn(process.execPath, [cliPath, 'run', '--minWorkers', '1', '--maxWorkers', '1', ...filteredArgs], {
+  stdio: 'inherit'
+});
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 1);
+});

--- a/src/pages/__tests__/budgets-page.test.tsx
+++ b/src/pages/__tests__/budgets-page.test.tsx
@@ -1,0 +1,208 @@
+import { render, screen, within, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { act } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Budget, BudgetSnapshot, Category } from '@domain/types';
+import { getMonthKey } from '@utils/dates';
+
+vi.mock('@services/category', () => ({
+  listCategories: vi.fn()
+}));
+
+vi.mock('@services/budget', () => ({
+  listBudgets: vi.fn(),
+  createBudget: vi.fn(),
+  updateBudget: vi.fn()
+}));
+
+vi.mock('@utils/useBudgetBadges', () => ({
+  useBudgetBadges: vi.fn()
+}));
+
+import { listCategories } from '@services/category';
+import { createBudget, listBudgets, updateBudget } from '@services/budget';
+import { useBudgetBadges } from '@utils/useBudgetBadges';
+import { BudgetsPage } from '../Budgets';
+
+const listCategoriesMock = vi.mocked(listCategories);
+const listBudgetsMock = vi.mocked(listBudgets);
+const createBudgetMock = vi.mocked(createBudget);
+const updateBudgetMock = vi.mocked(updateBudget);
+const useBudgetBadgesMock = vi.mocked(useBudgetBadges);
+
+const currentMonth = getMonthKey(new Date());
+
+const categories: Category[] = [
+  {
+    id: 'cat-food',
+    name: 'Groceries',
+    color: '#16a34a',
+    isHidden: false,
+    createdAt: `${currentMonth}-01T00:00:00.000Z`,
+    updatedAt: `${currentMonth}-01T00:00:00.000Z`
+  },
+  {
+    id: 'cat-travel',
+    name: 'Travel',
+    color: '#2563eb',
+    isHidden: false,
+    createdAt: `${currentMonth}-01T00:00:00.000Z`,
+    updatedAt: `${currentMonth}-01T00:00:00.000Z`
+  }
+];
+
+const baseBadges: BudgetSnapshot[] = [
+  {
+    categoryId: 'cat-food',
+    month: currentMonth,
+    limitCents: 30000,
+    actualCents: 12000,
+    carryInCents: 0,
+    availableCents: 18000,
+    status: 'ok'
+  }
+];
+
+let budgets: Budget[];
+const refreshSpy = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  budgets = [
+    {
+      id: 'budget-food',
+      month: currentMonth,
+      categoryId: 'cat-food',
+      limitCents: 30000,
+      carryOverPrev: false,
+      createdAt: `${currentMonth}-01T00:00:00.000Z`,
+      updatedAt: `${currentMonth}-01T00:00:00.000Z`
+    }
+  ];
+
+  refreshSpy.mockClear();
+
+  listCategoriesMock.mockResolvedValue(categories);
+  listBudgetsMock.mockImplementation(async (filters = {}) => {
+    let result = budgets;
+    if (filters.month) {
+      result = result.filter((budget) => budget.month === filters.month);
+    }
+    if (filters.categoryId) {
+      result = result.filter((budget) => budget.categoryId === filters.categoryId);
+    }
+    return [...result];
+  });
+
+  createBudgetMock.mockImplementation(async (input: any) => {
+    const budget: Budget = {
+      id: input.id ?? `budget-${Math.random().toString(36).slice(2, 8)}`,
+      month: input.month,
+      categoryId: input.categoryId,
+      limitCents: input.limitCents,
+      carryOverPrev: input.carryOverPrev ?? false,
+      createdAt: `${input.month}-01T00:00:00.000Z`,
+      updatedAt: `${input.month}-01T00:00:00.000Z`
+    };
+    budgets = [
+      ...budgets.filter((existing) => existing.id !== budget.id),
+      budget
+    ];
+    return budget;
+  });
+
+  updateBudgetMock.mockImplementation(async (id: string, patch: any) => {
+    const existing = budgets.find((budget) => budget.id === id);
+    if (!existing) {
+      throw new Error('Budget not found');
+    }
+    const updated: Budget = {
+      ...existing,
+      ...patch,
+      updatedAt: `${existing.month}-01T00:00:00.000Z`
+    };
+    budgets = budgets.map((budget) => (budget.id === id ? updated : budget));
+    return updated;
+  });
+
+  useBudgetBadgesMock.mockReturnValue({
+    badges: baseBadges,
+    isLoading: false,
+    error: null,
+    refresh: vi.fn(async () => {
+      refreshSpy();
+    })
+  });
+});
+
+describe('BudgetsPage', () => {
+  it('updates an existing budget and refreshes badges', async () => {
+    const user = userEvent.setup();
+    render(<BudgetsPage />);
+
+    await waitFor(() => expect(listCategoriesMock).toHaveBeenCalled());
+    await waitFor(() => expect(listBudgetsMock).toHaveBeenCalled());
+
+    const groceryHeading = await screen.findByRole('heading', { name: 'Groceries' });
+    const groceryCard = groceryHeading.closest('article');
+    if (!groceryCard) {
+      throw new Error('Expected groceries budget card');
+    }
+    const limitInput = within(groceryCard).getByLabelText('Monthly limit');
+
+    await user.clear(limitInput);
+    await user.type(limitInput, '310.00');
+
+    const saveButton = within(groceryCard).getByRole('button', { name: 'Save changes' });
+    expect(saveButton).toBeEnabled();
+
+    await act(async () => {
+      await user.click(saveButton);
+    });
+
+    await waitFor(() => expect(updateBudgetMock).toHaveBeenCalledWith('budget-food', {
+      limitCents: 31000,
+      carryOverPrev: false
+    }));
+    await waitFor(() => expect(refreshSpy).toHaveBeenCalled());
+    await screen.findByText('Budget saved. You’re in control.');
+  });
+
+  it('creates a new budget for a category without one', async () => {
+    const user = userEvent.setup();
+    render(<BudgetsPage />);
+
+    await waitFor(() => expect(listCategoriesMock).toHaveBeenCalled());
+    await waitFor(() => expect(listBudgetsMock).toHaveBeenCalled());
+
+    const travelHeading = await screen.findByRole('heading', { name: 'Travel' });
+    const travelCard = travelHeading.closest('article');
+    if (!travelCard) {
+      throw new Error('Expected travel budget card');
+    }
+    const limitInput = within(travelCard).getByLabelText('Monthly limit');
+
+    await user.clear(limitInput);
+    await user.type(limitInput, '150.00');
+
+    const createButton = within(travelCard).getByRole('button', { name: 'Create budget' });
+    expect(createButton).toBeEnabled();
+
+    await act(async () => {
+      await user.click(createButton);
+    });
+
+    await waitFor(() =>
+      expect(createBudgetMock).toHaveBeenCalledWith({
+        month: currentMonth,
+        categoryId: 'cat-travel',
+        limitCents: 15000,
+        carryOverPrev: false
+      })
+    );
+    await waitFor(() => expect(refreshSpy).toHaveBeenCalled());
+    await screen.findByText('Budget saved. You’re in control.');
+    expect(listBudgetsMock).toHaveBeenCalledWith({ month: currentMonth });
+  });
+});

--- a/src/pages/__tests__/log-page.test.tsx
+++ b/src/pages/__tests__/log-page.test.tsx
@@ -1,0 +1,235 @@
+import { render, screen, within, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { act } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Category, Expense } from '@domain/types';
+import { getMonthKey } from '@utils/dates';
+import type { ExpenseFilters } from '@services/expense';
+
+vi.mock('@services/category', () => ({
+  listCategories: vi.fn()
+}));
+
+vi.mock('@services/expense', () => ({
+  listExpenses: vi.fn(),
+  createExpense: vi.fn(),
+  updateExpense: vi.fn(),
+  deleteExpense: vi.fn()
+}));
+
+import { LogPage } from '../Log';
+import { listCategories } from '@services/category';
+import { createExpense, deleteExpense, listExpenses, updateExpense } from '@services/expense';
+
+const listCategoriesMock = vi.mocked(listCategories);
+const listExpensesMock = vi.mocked(listExpenses);
+const createExpenseMock = vi.mocked(createExpense);
+const updateExpenseMock = vi.mocked(updateExpense);
+const deleteExpenseMock = vi.mocked(deleteExpense);
+
+const currentMonth = getMonthKey(new Date());
+
+const categories: Category[] = [
+  {
+    id: 'cat-food',
+    name: 'Groceries',
+    color: '#16a34a',
+    isHidden: false,
+    createdAt: `${currentMonth}-01T00:00:00.000Z`,
+    updatedAt: `${currentMonth}-01T00:00:00.000Z`
+  },
+  {
+    id: 'cat-home',
+    name: 'Home',
+    color: '#2563eb',
+    isHidden: false,
+    createdAt: `${currentMonth}-01T00:00:00.000Z`,
+    updatedAt: `${currentMonth}-01T00:00:00.000Z`
+  }
+];
+
+const buildExpense = (overrides: Partial<Expense> = {}): Expense => ({
+  id: overrides.id ?? 'exp-1',
+  amountCents: overrides.amountCents ?? 950,
+  currency: 'EUR',
+  date: overrides.date ?? `${currentMonth}-10T12:00:00.000Z`,
+  month: overrides.month ?? currentMonth,
+  categoryId: overrides.categoryId ?? 'cat-food',
+  note: overrides.note,
+  createdAt: overrides.createdAt ?? `${currentMonth}-10T12:00:00.000Z`,
+  updatedAt: overrides.updatedAt ?? `${currentMonth}-10T12:00:00.000Z`
+});
+
+let expenses: Expense[];
+
+function applyExpenseFilters(items: Expense[], filters: ExpenseFilters = {}): Expense[] {
+  let result = [...items];
+  if (filters.month) {
+    result = result.filter((expense) => expense.month === filters.month);
+  }
+  if (filters.categoryId) {
+    result = result.filter((expense) => expense.categoryId === filters.categoryId);
+  }
+  if (filters.search) {
+    const query = filters.search.trim().toLowerCase();
+    if (query) {
+      result = result.filter((expense) => expense.note?.toLowerCase().includes(query));
+    }
+  }
+  const order = filters.order ?? 'desc';
+  result.sort((a, b) =>
+    order === 'asc' ? a.date.localeCompare(b.date) : b.date.localeCompare(a.date)
+  );
+  if (typeof filters.limit === 'number') {
+    result = result.slice(0, filters.limit);
+  }
+  return result;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  expenses = [buildExpense({ id: 'exp-1', note: 'Morning coffee', amountCents: 350 })];
+
+  listCategoriesMock.mockResolvedValue(categories);
+  listExpensesMock.mockImplementation(async (filters = {}) => applyExpenseFilters(expenses, filters));
+
+  createExpenseMock.mockImplementation(async (input: any) => {
+    const expense: Expense = {
+      id: input.id ?? `exp-${Math.random().toString(36).slice(2, 8)}`,
+      amountCents: input.amountCents,
+      currency: 'EUR',
+      date: input.date,
+      month: input.month ?? getMonthKey(input.date),
+      categoryId: input.categoryId,
+      note: input.note,
+      createdAt: input.createdAt ?? input.date,
+      updatedAt: input.updatedAt ?? input.date
+    };
+    expenses = [expense, ...expenses.filter((item) => item.id !== expense.id)];
+    return expense;
+  });
+
+  updateExpenseMock.mockImplementation(async (id: string, patch: any) => {
+    const existing = expenses.find((expense) => expense.id === id);
+    if (!existing) {
+      throw new Error('Expense not found');
+    }
+    const nextDate = patch.date ?? existing.date;
+    const updated: Expense = {
+      ...existing,
+      ...patch,
+      date: nextDate,
+      month: patch.month ?? getMonthKey(nextDate),
+      updatedAt: patch.updatedAt ?? nextDate
+    };
+    expenses = expenses.map((expense) => (expense.id === id ? updated : expense));
+    return updated;
+  });
+
+  deleteExpenseMock.mockImplementation(async (id: string) => {
+    expenses = expenses.filter((expense) => expense.id !== id);
+  });
+});
+
+describe('LogPage', () => {
+  it('creates a new expense and shows the undo banner', async () => {
+    const user = userEvent.setup();
+    render(<LogPage />);
+
+    await waitFor(() => expect(listCategoriesMock).toHaveBeenCalled());
+    await waitFor(() => expect(listExpensesMock).toHaveBeenCalled());
+
+    await screen.findByText('Latest entries');
+    await screen.findByText('Morning coffee');
+
+    const amountInput = screen.getByLabelText(/Amount/i, { selector: 'input[name="amount"]' });
+    await user.clear(amountInput);
+    await user.type(amountInput, '42.10');
+
+    const dateInput = screen.getByLabelText(/Date/i, { selector: 'input[type="date"]' });
+    await user.clear(dateInput);
+    await user.type(dateInput, `${currentMonth}-15`);
+
+    const noteInput = screen.getByLabelText('Note', { selector: 'textarea' });
+    await user.type(noteInput, 'Dinner with friends');
+
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: 'Add expense' }));
+    });
+
+    await waitFor(() => expect(createExpenseMock).toHaveBeenCalledTimes(1));
+    await screen.findByText('Dinner with friends');
+    expect(screen.getByRole('status')).toHaveTextContent('Expense saved.');
+  });
+
+  it('edits an existing expense and restores the form state', async () => {
+    const user = userEvent.setup();
+    render(<LogPage />);
+
+    await waitFor(() => expect(listCategoriesMock).toHaveBeenCalled());
+    await waitFor(() => expect(listExpensesMock).toHaveBeenCalled());
+
+    const row = await screen.findByText('Morning coffee');
+    const tableRow = row.closest('tr');
+    expect(tableRow).not.toBeNull();
+
+    if (!tableRow) {
+      return;
+    }
+
+    await act(async () => {
+      await user.click(within(tableRow).getByRole('button', { name: /edit/i }));
+    });
+
+    const noteInput = screen.getByLabelText('Note', { selector: 'textarea' });
+    await user.clear(noteInput);
+    await user.type(noteInput, 'Morning coffee updated');
+
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: 'Save changes' }));
+    });
+
+    await waitFor(() => expect(updateExpenseMock).toHaveBeenCalledTimes(1));
+    await screen.findByText('Morning coffee updated');
+    expect(screen.getByRole('status')).toHaveTextContent('Expense updated.');
+  });
+
+  it('deletes an expense and allows undoing the removal', async () => {
+    const user = userEvent.setup();
+    render(<LogPage />);
+
+    await waitFor(() => expect(listCategoriesMock).toHaveBeenCalled());
+    await waitFor(() => expect(listExpensesMock).toHaveBeenCalled());
+
+    const row = await screen.findByText('Morning coffee');
+    const tableRow = row.closest('tr');
+    expect(tableRow).not.toBeNull();
+
+    if (!tableRow) {
+      return;
+    }
+
+    await act(async () => {
+      await user.click(within(tableRow).getByRole('button', { name: /delete/i }));
+    });
+
+    const dialog = await screen.findByRole('alertdialog');
+    await act(async () => {
+      await user.click(within(dialog).getByRole('button', { name: 'Delete' }));
+    });
+
+    await waitFor(() => expect(deleteExpenseMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.queryByText('Morning coffee')).not.toBeInTheDocument());
+
+    const undoBanner = screen.getByRole('status');
+    expect(undoBanner).toHaveTextContent('Expense deleted.');
+
+    await act(async () => {
+      await user.click(within(undoBanner).getByRole('button', { name: /undo/i }));
+    });
+
+    await waitFor(() => expect(createExpenseMock).toHaveBeenCalledTimes(1));
+    await screen.findByText('Morning coffee');
+  });
+});

--- a/src/pages/__tests__/reports-page.test.tsx
+++ b/src/pages/__tests__/reports-page.test.tsx
@@ -1,0 +1,157 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { BudgetSnapshot, Category } from '@domain/types';
+import { getMonthKey, getPreviousMonthKey } from '@utils/dates';
+
+vi.mock('@services/category', () => ({
+  listCategories: vi.fn()
+}));
+
+vi.mock('@services/report', () => ({
+  getBudgetVsActual: vi.fn(),
+  getSpendByCategory: vi.fn(),
+  getTrendOverTime: vi.fn()
+}));
+
+vi.mock('chart.js', () => {
+  const destroy = vi.fn();
+  const Chart = vi.fn(() => ({ destroy }));
+  Chart.register = vi.fn();
+  Chart.defaults = { font: { family: '' }, color: '' } as any;
+  return {
+    Chart,
+    ArcElement: vi.fn(),
+    BarElement: vi.fn(),
+    CategoryScale: vi.fn(),
+    Legend: vi.fn(),
+    LineElement: vi.fn(),
+    LinearScale: vi.fn(),
+    PointElement: vi.fn(),
+    Tooltip: vi.fn()
+  };
+});
+
+import { listCategories } from '@services/category';
+import { getBudgetVsActual, getSpendByCategory, getTrendOverTime } from '@services/report';
+import { ReportsPage } from '../Reports';
+
+const listCategoriesMock = vi.mocked(listCategories);
+const getBudgetVsActualMock = vi.mocked(getBudgetVsActual);
+const getSpendByCategoryMock = vi.mocked(getSpendByCategory);
+const getTrendOverTimeMock = vi.mocked(getTrendOverTime);
+const originalGetContext = HTMLCanvasElement.prototype.getContext;
+const canvasContextMock = vi.fn(() => ({}));
+
+beforeAll(() => {
+  Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+    value: canvasContextMock,
+    configurable: true
+  });
+});
+
+afterEach(() => {
+  canvasContextMock.mockClear();
+});
+
+afterAll(() => {
+  if (originalGetContext) {
+    Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+      value: originalGetContext,
+      configurable: true
+    });
+  } else {
+    delete HTMLCanvasElement.prototype.getContext;
+  }
+});
+
+const currentMonth = getMonthKey(new Date());
+const previousMonth = getPreviousMonthKey(currentMonth);
+
+const categories: Category[] = [
+  {
+    id: 'cat-food',
+    name: 'Groceries',
+    color: '#16a34a',
+    isHidden: false,
+    createdAt: `${currentMonth}-01T00:00:00.000Z`,
+    updatedAt: `${currentMonth}-01T00:00:00.000Z`
+  },
+  {
+    id: 'cat-travel',
+    name: 'Travel',
+    color: '#2563eb',
+    isHidden: false,
+    createdAt: `${currentMonth}-01T00:00:00.000Z`,
+    updatedAt: `${currentMonth}-01T00:00:00.000Z`
+  }
+];
+
+const budgetSnapshots: BudgetSnapshot[] = [
+  {
+    categoryId: 'cat-food',
+    month: currentMonth,
+    limitCents: 50000,
+    actualCents: 40000,
+    carryInCents: 1000,
+    availableCents: 11000,
+    status: 'ok'
+  },
+  {
+    categoryId: 'cat-travel',
+    month: currentMonth,
+    limitCents: 30000,
+    actualCents: 35000,
+    carryInCents: 0,
+    availableCents: -5000,
+    status: 'over'
+  }
+];
+
+const categorySpend = [
+  { categoryId: 'cat-food', month: currentMonth, totalCents: 40000 },
+  { categoryId: 'cat-travel', month: currentMonth, totalCents: 35000 }
+];
+
+const trend = [
+  { month: previousMonth, totalCents: 60000 },
+  { month: currentMonth, totalCents: 75000 }
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  listCategoriesMock.mockResolvedValue(categories);
+  getBudgetVsActualMock.mockResolvedValue(budgetSnapshots);
+  getSpendByCategoryMock.mockResolvedValue(categorySpend);
+  getTrendOverTimeMock.mockResolvedValue(trend);
+});
+
+describe('ReportsPage', () => {
+  it('renders insights, summary metrics, and chart sections', async () => {
+    render(<ReportsPage />);
+
+    await screen.findByText('Budget vs actual');
+
+    const summary = screen.getByLabelText('Month summary');
+    expect(summary).toHaveTextContent('Budgeted');
+    expect(summary.textContent).toMatch(/€\s*810\.00/);
+    expect(summary.textContent).toMatch(/€\s*750\.00/);
+    expect(summary.textContent).toMatch(/€\s*60\.00/);
+    expect(summary).toHaveTextContent('93%');
+    expect(summary).toHaveTextContent('Groceries');
+
+    expect(screen.getByText(/You’re over last month by/i)).toBeInTheDocument();
+    expect(screen.getByText(/You’re over by/i)).toBeInTheDocument();
+
+    expect(await screen.findByText('Budget vs actual')).toBeInTheDocument();
+    expect(screen.getByText('Category breakdown')).toBeInTheDocument();
+    expect(screen.getByText('Trends')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(listCategoriesMock).toHaveBeenCalledWith({ includeHidden: true });
+      expect(getBudgetVsActualMock).toHaveBeenCalledWith(currentMonth);
+      expect(getSpendByCategoryMock).toHaveBeenCalledWith(currentMonth);
+      expect(getTrendOverTimeMock).toHaveBeenCalledWith({ startMonth: currentMonth, monthsBack: 11 });
+    });
+  });
+});

--- a/src/services/__tests__/expense.service.test.ts
+++ b/src/services/__tests__/expense.service.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ExpenseRecord } from '@db/db';
+import { listExpenses, type ExpenseFilters } from '../expense';
+
+class FakeCollection {
+  constructor(private readonly records: ExpenseRecord[]) {}
+
+  and(predicate: (expense: ExpenseRecord) => boolean): FakeCollection {
+    return new FakeCollection(this.records.filter(predicate));
+  }
+
+  async toArray(): Promise<ExpenseRecord[]> {
+    return [...this.records];
+  }
+}
+
+class FakeExpenseTable {
+  constructor(private readonly records: ExpenseRecord[]) {}
+
+  where(field: string): { equals: (value: string) => FakeCollection } {
+    if (field !== 'month') {
+      throw new Error(`Unsupported where field: ${field}`);
+    }
+    return {
+      equals: (value: string) =>
+        new FakeCollection(this.records.filter((record) => record.month === value))
+    };
+  }
+
+  toCollection(): FakeCollection {
+    return new FakeCollection([...this.records]);
+  }
+}
+
+function listWithFilters(records: ExpenseRecord[], filters: ExpenseFilters): Promise<any> {
+  const table = new FakeExpenseTable(records);
+  return listExpenses(filters, { expenses: table } as any);
+}
+
+describe('listExpenses', () => {
+  const baseRecords: ExpenseRecord[] = [
+    {
+      id: 'exp-1',
+      amountCents: 1200,
+      currency: 'EUR',
+      date: '2024-05-15T10:00:00.000Z',
+      month: '2024-05',
+      categoryId: 'cat-food',
+      note: 'Groceries and milk',
+      createdAt: '2024-05-15T10:00:00.000Z',
+      updatedAt: '2024-05-15T10:00:00.000Z'
+    },
+    {
+      id: 'exp-2',
+      amountCents: 2500,
+      currency: 'EUR',
+      date: '2024-05-10T09:00:00.000Z',
+      month: '2024-05',
+      categoryId: 'cat-transport',
+      note: 'Bus pass',
+      createdAt: '2024-05-10T09:00:00.000Z',
+      updatedAt: '2024-05-10T09:00:00.000Z'
+    },
+    {
+      id: 'exp-3',
+      amountCents: 5400,
+      currency: 'EUR',
+      date: '2024-04-28T12:00:00.000Z',
+      month: '2024-04',
+      categoryId: 'cat-food',
+      note: 'Groceries for week',
+      createdAt: '2024-04-28T12:00:00.000Z',
+      updatedAt: '2024-04-28T12:00:00.000Z'
+    },
+    {
+      id: 'exp-4',
+      amountCents: 900,
+      currency: 'EUR',
+      date: '2024-05-20T18:00:00.000Z',
+      month: '2024-05',
+      categoryId: 'cat-food',
+      note: 'Milk and bread',
+      createdAt: '2024-05-20T18:00:00.000Z',
+      updatedAt: '2024-05-20T18:00:00.000Z'
+    }
+  ];
+
+  it('filters by month, category, and search term while sorting newest first by default', async () => {
+    const expenses = await listWithFilters(baseRecords, {
+      month: '2024-05',
+      categoryId: 'cat-food',
+      search: 'MILK'
+    });
+
+    expect(expenses).toHaveLength(2);
+    expect(expenses.map((expense: any) => expense.id)).toEqual(['exp-4', 'exp-1']);
+  });
+
+  it('respects explicit ordering and limit options', async () => {
+    const expenses = await listWithFilters(baseRecords, {
+      month: '2024-05',
+      order: 'asc',
+      limit: 2
+    });
+
+    expect(expenses).toHaveLength(2);
+    expect(expenses.map((expense: any) => expense.id)).toEqual(['exp-2', 'exp-1']);
+  });
+});

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,1 +1,1 @@
-// Test setup placeholder – extend with shared mocks when needed.
+import '@testing-library/jest-dom/vitest';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,6 +18,16 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],
-    globals: true
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov'],
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: ['src/main.tsx'],
+      lines: 80,
+      functions: 80,
+      statements: 80,
+      branches: 70
+    }
   }
 });


### PR DESCRIPTION
## Summary
- add Vitest + Testing Library coverage for the Log, Budgets, and Reports pages to exercise core user flows
- introduce regression tests for the expense listing service to cover filtering, ordering, and limits
- wire up a pnpm-based CI workflow and document the badge along with a reusable test runner script

## Testing
- pnpm test --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68da1d76041c8326b714a96fc8194c07